### PR TITLE
refactor(macros): rename tui! macro to node! for improved semantic clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ impl Counter {
     fn view(&self, ctx: &Context) -> Node {
         let state = ctx.get_state::<CounterState>();
 
-        tui! {
+        node! {
             div(bg: blue, pad: 2) [
                 text(format!("Count: {}", state.count), color: white, bold),
                 spacer(1),
@@ -189,14 +189,14 @@ The beauty of this pattern is that each component is independent. You can develo
 
 RxTUI provides two different APIs for building UIs, each suited to different use cases. Understanding when to use each one is key to productive development.
 
-### 1. The tui! Macro (Declarative)
+### 1. The node! Macro (Declarative)
 
 Best for: **Most UI code, especially view methods**
 
-The `tui!` macro provides a JSX-like syntax that's concise and readable:
+The `node!` macro provides a JSX-like syntax that's concise and readable:
 
 ```rust
-tui! {
+node! {
     div(bg: blue, pad: 2) [
         text("Hello", color: white),
         div(border: white) [
@@ -253,10 +253,10 @@ for (i, item) in items.iter().enumerate() {
 
 Here's a simple decision tree:
 
-1. **Writing a view method?** → Use `tui!` macro
+1. **Writing a view method?** → Use `node!` macro
 2. **Building UI from dynamic data?** → Use Builder API
 3. **Creating a reusable component library?** → Use Builder API
-4. **Prototyping quickly?** → Use `tui!` macro
+4. **Prototyping quickly?** → Use `node!` macro
 
 ## Component Communication
 
@@ -269,7 +269,7 @@ Components send messages to themselves through event handlers:
 ```rust
 impl MyComponent {
     fn view(&self, ctx: &Context) -> Node {
-        tui! {
+        node! {
             div [
                 text("Click me"),
                 @click: ctx.handler(MyMsg::Clicked)  // Sends to this component
@@ -360,7 +360,7 @@ impl Reader {
         // Read shared state from topic
         let shared = ctx.read_topic::<SharedDashboardState>("shared.dashboard");
 
-        tui! {
+        node! {
             div [
                 text(format!("Shared value: {:?}", shared))
             ]
@@ -378,7 +378,7 @@ impl Parent {
     fn view(&self, ctx: &Context) -> Node {
         let state = ctx.get_state::<ParentState>();
 
-        tui! {
+        node! {
             div [
                 // Pass data to child via constructor
                 node(ChildComponent::new(state.child_config.clone())),
@@ -534,7 +534,7 @@ Build complex interfaces from simple, focused components:
 ```rust
 impl App {
     fn view(&self, ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(dir: vertical) [
                 node(Header::new(&self.title)),
 
@@ -557,7 +557,7 @@ Each component handles its own concerns, making the overall structure clear and 
 For inline styling, use RichText:
 
 ```rust
-tui! {
+node! {
     richtext [
         text("Error: ", color: red, bold),
         text("File "),
@@ -587,7 +587,7 @@ struct FormState {
 
 impl Form {
     fn view(&self, ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(pad: 2) [
                 text("Username:"),
                 input(placeholder: "Enter username", focusable),

--- a/rxtui/examples/components.rs
+++ b/rxtui/examples/components.rs
@@ -102,7 +102,7 @@ impl Counter {
     fn view(&self, ctx: &Context) -> Node {
         let state = ctx.get_state::<CounterState>();
 
-        tui! {
+        node! {
             div(
                 bg: black,
                 border: white,
@@ -172,7 +172,7 @@ impl Dashboard {
     fn view(&self, ctx: &Context) -> Node {
         let state = ctx.get_state::<DashboardState>();
 
-        tui! {
+        node! {
             div(bg: black, pad: 2, dir: vertical) [
                 div(bg: blue, pad: 1, w_pct: 1.0) [
                     text(&state.title, color: bright_white)

--- a/rxtui/examples/demo.rs
+++ b/rxtui/examples/demo.rs
@@ -83,26 +83,26 @@ impl Demo {
         let state = ctx.get_state::<DemoState>();
 
         let page_content = match state.current_page {
-            1 => tui! { node(page1_overflow::Page1OverflowDemo::new()) },
-            2 => tui! { node(page2_direction::Page2DirectionDemo::new()) },
-            3 => tui! { node(page3_percentages::Page3PercentagesDemo::new()) },
-            4 => tui! { node(page4_borders::Page4BordersDemo::new()) },
-            5 => tui! { node(page5_absolute::Page5AbsoluteDemo::new()) },
-            6 => tui! { node(page6_text_styles::Page6TextStylesDemo::new()) },
-            7 => tui! { node(page7_auto_sizing::Page7AutoSizingDemo::new()) },
-            8 => tui! { node(page8_text_wrap::Page8TextWrapDemo::new()) },
-            9 => tui! { node(page9_element_wrap::Page9ElementWrapDemo::new()) },
-            10 => tui! { node(page10_unicode::Page10UnicodeDemo::new()) },
-            11 => tui! { node(page11_content_sizing::Page11ContentSizingDemo::new()) },
-            12 => tui! { node(page12_focus::Page12FocusDemo::new()) },
-            13 => tui! { node(page13_rich_text::Page13::new()) },
-            14 => tui! { node(page14_text_input::Page14TextInputDemo::new()) },
-            15 => tui! { node(page15_scrollable::Page15ScrollableDemo::new()) },
-            _ => tui! { node(page1_overflow::Page1OverflowDemo::new()) },
+            1 => node! { node(page1_overflow::Page1OverflowDemo::new()) },
+            2 => node! { node(page2_direction::Page2DirectionDemo::new()) },
+            3 => node! { node(page3_percentages::Page3PercentagesDemo::new()) },
+            4 => node! { node(page4_borders::Page4BordersDemo::new()) },
+            5 => node! { node(page5_absolute::Page5AbsoluteDemo::new()) },
+            6 => node! { node(page6_text_styles::Page6TextStylesDemo::new()) },
+            7 => node! { node(page7_auto_sizing::Page7AutoSizingDemo::new()) },
+            8 => node! { node(page8_text_wrap::Page8TextWrapDemo::new()) },
+            9 => node! { node(page9_element_wrap::Page9ElementWrapDemo::new()) },
+            10 => node! { node(page10_unicode::Page10UnicodeDemo::new()) },
+            11 => node! { node(page11_content_sizing::Page11ContentSizingDemo::new()) },
+            12 => node! { node(page12_focus::Page12FocusDemo::new()) },
+            13 => node! { node(page13_rich_text::Page13::new()) },
+            14 => node! { node(page14_text_input::Page14TextInputDemo::new()) },
+            15 => node! { node(page15_scrollable::Page15ScrollableDemo::new()) },
+            _ => node! { node(page1_overflow::Page1OverflowDemo::new()) },
         };
 
-        // Since tui! macro doesn't support variables as children, I need to create this manually
-        let header = tui! {
+        // Since node! macro doesn't support variables as children, I need to create this manually
+        let header = node! {
             div(bg: bright_black, dir: horizontal, pad: 1, w_pct: 1.0, h: 3) [
                 text("Radical TUI Demo", color: bright_cyan),
                 div(w: 10) [],
@@ -110,7 +110,7 @@ impl Demo {
             ]
         };
 
-        let tab_bar = tui! { node(TabBar::new(state.current_page)) };
+        let tab_bar = node! { node(TabBar::new(state.current_page)) };
 
         // Combine using builder pattern
         let container = Div::new()
@@ -168,7 +168,7 @@ impl TabBar {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: blue, dir: horizontal, h: 3, w_pct: 1.0) [
                 node(Tab::new(1, "[1] Overflow", self.current_page)),
                 node(Tab::new(2, "[2] Direction", self.current_page)),
@@ -227,7 +227,7 @@ impl Tab {
         let label = self.label.clone();
         let page_num = self.page_num;
 
-        tui! {
+        node! {
             div(bg: (bg_color), pad: 1, h: 3, w_auto) [
                 text(label, color: (text_color)),
                 @click: ctx.topic_handler("navigation", DemoMessage::SetPage(page_num))

--- a/rxtui/examples/demo_pages/page10_unicode.rs
+++ b/rxtui/examples/demo_pages/page10_unicode.rs
@@ -23,7 +23,7 @@ impl Page10UnicodeDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h_pct: 1.0) [
                 // Title
                 text("Page 10: Unicode Text Rendering", color: cyan, bold, underline),

--- a/rxtui/examples/demo_pages/page11_content_sizing.rs
+++ b/rxtui/examples/demo_pages/page11_content_sizing.rs
@@ -23,7 +23,7 @@ impl Page11ContentSizingDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 60) [
                 // Title
                 text("Page 11: Content-Based Sizing", color: bright_white, bold),

--- a/rxtui/examples/demo_pages/page12_focus.rs
+++ b/rxtui/examples/demo_pages/page12_focus.rs
@@ -24,7 +24,7 @@ impl Page12FocusDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 50) [
                 // Title
                 text("Page 12: Focus Management Demo", color: bright_white, bold),
@@ -133,7 +133,7 @@ impl FocusButton {
         let label = self.label.clone();
         let color = self.color;
 
-        tui! {
+        node! {
             div(
                 border_style: (BorderStyle::Single, color),
                 pad: 1,

--- a/rxtui/examples/demo_pages/page13_rich_text.rs
+++ b/rxtui/examples/demo_pages/page13_rich_text.rs
@@ -22,7 +22,7 @@ impl Page13 {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 1, w_pct: 1.0) [
                 // Title
                 text("Page 13: RichText Demo", color: bright_white),

--- a/rxtui/examples/demo_pages/page14_text_input.rs
+++ b/rxtui/examples/demo_pages/page14_text_input.rs
@@ -23,7 +23,7 @@ impl Page14TextInputDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 50) [
                 // Title
                 text("Page 14: TextInput Components", color: bright_white, bold),

--- a/rxtui/examples/demo_pages/page15_scrollable.rs
+++ b/rxtui/examples/demo_pages/page15_scrollable.rs
@@ -74,7 +74,7 @@ impl Page15ScrollableDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 60) [
                 // Title
                 text("Page 15: Scrollable Content - Use arrow keys or mouse wheel to scroll", color: bright_white),

--- a/rxtui/examples/demo_pages/page1_overflow.rs
+++ b/rxtui/examples/demo_pages/page1_overflow.rs
@@ -137,7 +137,7 @@ impl Page1OverflowDemo {
         let level2_color = colors[state.level2_color_idx];
         let level3_color = colors[state.level3_color_idx];
 
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 60) [
                 // Title
                 text("Page 1: Overflow Behavior", color: bright_white),

--- a/rxtui/examples/demo_pages/page2_direction.rs
+++ b/rxtui/examples/demo_pages/page2_direction.rs
@@ -23,7 +23,7 @@ impl Page2DirectionDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 45) [
                 // Title
                 text("Page 2: Direction Examples", color: bright_white),

--- a/rxtui/examples/demo_pages/page3_percentages.rs
+++ b/rxtui/examples/demo_pages/page3_percentages.rs
@@ -23,7 +23,7 @@ impl Page3PercentagesDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 50) [
                 // Title
                 text("Page 3: Percentage Dimensions", color: bright_white),

--- a/rxtui/examples/demo_pages/page4_borders.rs
+++ b/rxtui/examples/demo_pages/page4_borders.rs
@@ -23,7 +23,7 @@ impl Page4BordersDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 1, w_pct: 1.0, h: 60) [
                 // Title
                 text("Page 4: Borders Demo", color: bright_white),

--- a/rxtui/examples/demo_pages/page5_absolute.rs
+++ b/rxtui/examples/demo_pages/page5_absolute.rs
@@ -57,7 +57,7 @@ impl Page5AbsoluteDemo {
             format!("Layer {}", state.selected_layer)
         };
 
-        let main_content = tui! {
+        let main_content = node! {
             div(bg: black, dir: vertical, pad: 1, w_pct: 1.0, h: 60) [
                 // Title and instructions
                 text("Page 5: Absolute Positioning & Z-Index Demo", color: bright_white),
@@ -181,7 +181,7 @@ impl Page5AbsoluteDemo {
 
         // Add modal if visible
         if state.show_modal {
-            let modal = tui! {
+            let modal = node! {
                 div(
                     pos: fixed,
                     top: 8,

--- a/rxtui/examples/demo_pages/page6_text_styles.rs
+++ b/rxtui/examples/demo_pages/page6_text_styles.rs
@@ -23,7 +23,7 @@ impl Page6TextStylesDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 50) [
                 // Title
                 text("Page 6: Text Styling Demo", color: bright_white, bold),

--- a/rxtui/examples/demo_pages/page7_auto_sizing.rs
+++ b/rxtui/examples/demo_pages/page7_auto_sizing.rs
@@ -23,7 +23,7 @@ impl Page7AutoSizingDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 60) [
                 // Title
                 text("Page 7: Auto Sizing", color: bright_white),

--- a/rxtui/examples/demo_pages/page8_text_wrap.rs
+++ b/rxtui/examples/demo_pages/page8_text_wrap.rs
@@ -23,7 +23,7 @@ impl Page8TextWrapDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h: 60) [
                 // Title
                 text("Page 8: Text Wrapping Examples", color: bright_white),

--- a/rxtui/examples/demo_pages/page9_element_wrap.rs
+++ b/rxtui/examples/demo_pages/page9_element_wrap.rs
@@ -23,7 +23,7 @@ impl Page9ElementWrapDemo {
     }
 
     fn view(&self, _ctx: &Context) -> Node {
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 2, w_pct: 1.0, h_pct: 1.0) [
                 // Title
                 text("Page 9: Element Wrapping Demo", color: cyan, bold, underline),

--- a/rxtui/examples/simple.rs
+++ b/rxtui/examples/simple.rs
@@ -78,7 +78,7 @@ impl ColorDemo {
     fn view(&self, ctx: &Context) -> Node {
         let state = ctx.get_state::<ColorDemoState>();
 
-        tui! {
+        node! {
             div(bg: black, dir: vertical, pad: 1) [
                 // Title bar
                 hstack(bg: "#333333", pad: 1, w: 80, h: 3) [

--- a/rxtui/lib/macros/internal.rs
+++ b/rxtui/lib/macros/internal.rs
@@ -1,4 +1,4 @@
-//! Internal macros used by the tui! macro
+//! Internal macros used by the node! macro
 //! These are not part of the public API
 
 /// Converts color values to the Color type

--- a/rxtui/lib/macros/mod.rs
+++ b/rxtui/lib/macros/mod.rs
@@ -1,11 +1,11 @@
 //! Macro-based DSL for building TUI components
 //!
-//! This module provides the `tui!` macro for composing rxtui components
+//! This module provides the `node!` macro for composing rxtui components
 //! with an ergonomic, declarative syntax.
 //!
 //! # Overview
 //!
-//! The `tui!` macro reduces boilerplate by 50-70% compared to the builder pattern
+//! The `node!` macro reduces boilerplate by 50-70% compared to the builder pattern
 //! while maintaining type safety and readability.
 //!
 //! # Syntax
@@ -23,7 +23,7 @@
 //! use rxtui::prelude::*;
 //!
 //! fn view(&self, ctx: &Context) -> Node {
-//!     tui! {
+//!     node! {
 //!         container(bg: black, pad: 2) [
 //!             text("Hello World", color: white, bold),
 //!             spacer(1),

--- a/rxtui/lib/macros/tui.rs
+++ b/rxtui/lib/macros/tui.rs
@@ -1,6 +1,6 @@
-//! Implementation of the tui! macro
+//! Implementation of the node! macro
 //!
-//! This file contains the main tui! macro and its internal parsing/building helpers.
+//! This file contains the main node! macro and its internal parsing/building helpers.
 //! The macro provides a declarative syntax for building TUI components.
 
 /// Main macro for building TUI components with a declarative syntax
@@ -19,7 +19,7 @@
 /// ```ignore
 /// use rxtui::prelude::*;
 ///
-/// tui! {
+/// node! {
 ///     div(bg: black, pad: 2) [
 ///         text("Hello World", color: white, bold),
 ///         text("Welcome to Radical TUI", color: cyan)
@@ -29,7 +29,7 @@
 ///
 /// ## Layout with HStack and VStack
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div(bg: "#1a1a1a", pad: 2) [
 ///         // Vertical layout by default
 ///         text("Header", color: yellow, bold),
@@ -59,7 +59,7 @@
 ///
 /// ## Styling Properties
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div(
 ///         // Colors
 ///         bg: black,              // Named color
@@ -110,7 +110,7 @@
 ///
 /// ## Text Styling
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div [
 ///         // Basic text styles
 ///         text("Bold text", bold),
@@ -135,7 +135,7 @@
 ///
 /// ## Text Input Fields
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div [
 ///         // Basic input with placeholder
 ///         input(placeholder: "Enter your name...", focusable),
@@ -164,7 +164,7 @@
 ///
 /// ## Rich Text (Inline Styled Text)
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div [
 ///         // Basic richtext with multiple styled segments
 ///         richtext [
@@ -227,7 +227,7 @@
 ///
 /// ## Event Handlers
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div(bg: black) [
 ///         // Click handler
 ///         container(bg: blue, focusable) [
@@ -259,7 +259,7 @@
 ///
 /// ## Dynamic Content
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div(bg: black) [
 ///         // Conditional text
 ///         text(
@@ -295,7 +295,7 @@
 /// These properties are only applied when the value is `Some`:
 ///
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div(
 ///         // Optional properties - only applied if Some
 ///         bg: (state.optional_background)!,      // Option<Color>
@@ -326,7 +326,7 @@
 ///
 /// ## Nested Components
 /// ```ignore
-/// tui! {
+/// node! {
 ///     div(bg: black, dir: vertical) [
 ///         // Include other components
 ///         node(Header::new("My App")),
@@ -396,7 +396,7 @@
 /// 4. **Colors without prefix** - No need for `Color::` prefix on named colors
 /// 5. **Expressions need parens** - Complex expressions should be wrapped in parentheses
 #[macro_export]
-macro_rules! tui {
+macro_rules! node {
     // Parse the root element
     ($($tt:tt)*) => {{
         $crate::tui_parse_element!($($tt)*)

--- a/rxtui/lib/prelude.rs
+++ b/rxtui/lib/prelude.rs
@@ -37,4 +37,4 @@ pub use crate::key::Key;
 pub use crate::bounds::Rect;
 
 // Main macro for building TUI components
-pub use crate::tui;
+pub use crate::node;

--- a/rxtui/tests/macro_tests.rs
+++ b/rxtui/tests/macro_tests.rs
@@ -1,4 +1,4 @@
-//! Tests for the tui! macro DSL
+//! Tests for the node! macro DSL
 
 use rxtui::prelude::*;
 
@@ -8,7 +8,7 @@ use rxtui::prelude::*;
 
 #[test]
 fn test_empty_div() {
-    let node = tui! {
+    let node = node! {
         div []
     };
 
@@ -20,7 +20,7 @@ fn test_empty_div() {
 
 #[test]
 fn test_div_with_basic_props() {
-    let node = tui! {
+    let node = node! {
         div(bg: black, pad: 2, w: 50, h: 20) []
     };
 
@@ -32,7 +32,7 @@ fn test_div_with_basic_props() {
 
 #[test]
 fn test_div_with_hex_color() {
-    let node = tui! {
+    let node = node! {
         div(bg: "#FF5733", border: "#00FF00") []
     };
 
@@ -44,7 +44,7 @@ fn test_div_with_hex_color() {
 
 #[test]
 fn test_div_with_percentage_dimensions() {
-    let node = tui! {
+    let node = node! {
         div(w_pct: 0.5, h_pct: 0.8) []
     };
 
@@ -56,7 +56,7 @@ fn test_div_with_percentage_dimensions() {
 
 #[test]
 fn test_container_with_auto_dimensions() {
-    let node = tui! {
+    let node = node! {
         div(w_auto, h_content) []
     };
 
@@ -72,7 +72,7 @@ fn test_container_with_auto_dimensions() {
 
 #[test]
 fn test_simple_text() {
-    let node = tui! {
+    let node = node! {
         div [
             text("Hello World")
         ]
@@ -88,7 +88,7 @@ fn test_simple_text() {
 
 #[test]
 fn test_text_with_color() {
-    let node = tui! {
+    let node = node! {
         div [
             text("Colored text", color: red)
         ]
@@ -104,7 +104,7 @@ fn test_text_with_color() {
 
 #[test]
 fn test_text_with_multiple_styles() {
-    let node = tui! {
+    let node = node! {
         div [
             text("Styled text", color: yellow, bg: blue, bold, underline)
         ]
@@ -120,7 +120,7 @@ fn test_text_with_multiple_styles() {
 
 #[test]
 fn test_text_with_bright_colors() {
-    let node = tui! {
+    let node = node! {
         div [
             text("Bright colors", color: bright_yellow, bg: bright_blue)
         ]
@@ -136,7 +136,7 @@ fn test_text_with_bright_colors() {
 
 #[test]
 fn test_text_with_wrap() {
-    let node = tui! {
+    let node = node! {
         div [
             text("Long text that should wrap", wrap: word)
         ]
@@ -156,7 +156,7 @@ fn test_text_with_wrap() {
 
 #[test]
 fn test_vbox_layout() {
-    let node = tui! {
+    let node = node! {
         vstack [
             text("Line 1"),
             text("Line 2"),
@@ -178,7 +178,7 @@ fn test_vbox_layout() {
 
 #[test]
 fn test_hbox_layout() {
-    let node = tui! {
+    let node = node! {
         hstack(gap: 2) [
             text("Left"),
             text("Center"),
@@ -199,7 +199,7 @@ fn test_hbox_layout() {
 
 #[test]
 fn test_nested_layouts() {
-    let node = tui! {
+    let node = node! {
         vstack [
             text("Header"),
             hstack [
@@ -228,7 +228,7 @@ fn test_nested_layouts() {
 
 #[test]
 fn test_spacer() {
-    let node = tui! {
+    let node = node! {
         div [
             text("Above"),
             spacer(2),
@@ -251,7 +251,7 @@ fn test_spacer() {
 #[test]
 fn test_dynamic_text() {
     let count = 42;
-    let node = tui! {
+    let node = node! {
         div [
             text(format!("Count: {}", count), bold)
         ]
@@ -268,7 +268,7 @@ fn test_dynamic_text() {
 #[test]
 fn test_conditional_color() {
     let is_error = true;
-    let node = tui! {
+    let node = node! {
         div(bg: (if is_error { Color::Red } else { Color::Green })) [
             text("Status")
         ]
@@ -288,7 +288,7 @@ fn test_conditional_color() {
 #[test]
 fn test_conditional_text() {
     let logged_in = false;
-    let node = tui! {
+    let node = node! {
         div [
             text(
                 if logged_in { "Welcome!" } else { "Please login" },
@@ -311,7 +311,7 @@ fn test_conditional_text() {
 
 #[test]
 fn test_absolute_positioning() {
-    let node = tui! {
+    let node = node! {
         div(pos: absolute, top: 5, left: 10, z: 100) []
     };
 
@@ -329,7 +329,7 @@ fn test_absolute_positioning() {
 
 #[test]
 fn test_absolute_shorthand() {
-    let node = tui! {
+    let node = node! {
         div(absolute, top: 0, right: 0) []
     };
 
@@ -350,7 +350,7 @@ fn test_absolute_shorthand() {
 
 #[test]
 fn test_deeply_nested_structure() {
-    let node = tui! {
+    let node = node! {
         div(bg: black, pad: 2) [
             text("Title", color: yellow, bold),
             spacer(1),
@@ -390,11 +390,11 @@ fn test_deeply_nested_structure() {
 
 #[test]
 fn test_direction_shortcuts() {
-    let node1 = tui! {
+    let node1 = node! {
         div(dir: v) []
     };
 
-    let node2 = tui! {
+    let node2 = node! {
         div(dir: h) []
     };
 
@@ -415,7 +415,7 @@ fn test_direction_shortcuts() {
 
 #[test]
 fn test_all_color_names() {
-    let node = tui! {
+    let node = node! {
         vstack [
             text("Black", color: black),
             text("Red", color: red),
@@ -438,7 +438,7 @@ fn test_all_color_names() {
 
 #[test]
 fn test_wrap_and_overflow_modes() {
-    let node = tui! {
+    let node = node! {
         div(wrap: wrap, overflow: hidden) [
             text("Content", wrap: word)
         ]
@@ -460,7 +460,7 @@ fn test_wrap_and_overflow_modes() {
 
 #[test]
 fn test_focusable_div() {
-    let node = tui! {
+    let node = node! {
         div(focusable) []
     };
 
@@ -475,7 +475,7 @@ fn test_focusable_div() {
 #[test]
 fn test_focusable_with_value() {
     let should_focus = false;
-    let node = tui! {
+    let node = node! {
         div(focusable: should_focus) []
     };
 
@@ -493,7 +493,7 @@ fn test_focusable_with_value() {
 
 #[test]
 fn test_empty_text() {
-    let node = tui! {
+    let node = node! {
         div [
             text("")
         ]
@@ -509,7 +509,7 @@ fn test_empty_text() {
 
 #[test]
 fn test_multiple_children_with_trailing_comma() {
-    let node = tui! {
+    let node = node! {
         div [
             text("First"),
             text("Second"),
@@ -530,7 +530,7 @@ fn test_expression_in_dimensions() {
     let window_width = 100;
     let window_height = 50;
 
-    let node = tui! {
+    let node = node! {
         div(
             w: (window_width / 2),
             h: (window_height - 10)


### PR DESCRIPTION
## Description

This PR renames the main declarative macro from `tui!` to `node!` to better reflect its purpose of creating UI nodes/elements in the component tree. The new name provides clearer semantic meaning and aligns with modern UI framework conventions.

## Changes

### Core Changes
- Renamed macro definition from `tui!` to `node!` in `rxtui/lib/macros/tui.rs`
- Updated prelude export to use `node!` instead of `tui!`

### Documentation Updates
- Updated all macro documentation and examples in source files
- Updated README.md to reflect the new macro name
- Updated module documentation in `rxtui/lib/macros/mod.rs` and `internal.rs`

### Code Updates
- Updated all 18 example files to use `node!` macro
- Updated all macro tests in `rxtui/tests/macro_tests.rs`
- Total of 24 files modified with consistent renaming


## Testing

- All existing tests have been updated and pass successfully
- `cargo test` runs without errors
- `cargo check --all-targets` completes successfully
- All examples compile and run correctly with the new macro name

## Checklist

- [x] Code compiles without warnings
- [x] All tests pass
- [x] Documentation has been updated
- [x] Examples have been updated