### PR TITLE
feat(context): add ergonomic send methods for message passing

### DIFF
--- a/rxtui/lib/app/context.rs
+++ b/rxtui/lib/app/context.rs
@@ -67,7 +67,7 @@ impl Dispatcher {
         }
     }
 
-    pub fn send(&self, component_id: ComponentId, message: Box<dyn Message>) {
+    pub fn send_to(&self, component_id: ComponentId, message: Box<dyn Message>) {
         let mut queues = self.queues.borrow_mut();
         queues.entry(component_id).or_default().push_back(message);
     }
@@ -218,7 +218,7 @@ impl Context {
         let id = self.current_component_id.clone();
         let dispatcher = self.dispatch.clone();
         move || {
-            dispatcher.send(id.clone(), Box::new(msg.clone()));
+            dispatcher.send_to(id.clone(), Box::new(msg.clone()));
         }
     }
 
@@ -231,7 +231,7 @@ impl Context {
         let id = self.current_component_id.clone();
         let dispatcher = self.dispatch.clone();
         move |value| {
-            dispatcher.send(id.clone(), msg_fn(value));
+            dispatcher.send_to(id.clone(), msg_fn(value));
         }
     }
 
@@ -248,6 +248,17 @@ impl Context {
     /// Read state from a topic
     pub fn read_topic<T: State + Clone + 'static>(&self, topic: &str) -> Option<T> {
         self.topics.read_topic(topic)
+    }
+
+    /// Send a message to the current component
+    pub fn send(&self, message: Box<dyn Message>) {
+        self.dispatch
+            .send_to(self.current_component_id.clone(), message);
+    }
+
+    /// Send a message to a specific component
+    pub fn send_to(&self, component_id: ComponentId, message: Box<dyn Message>) {
+        self.dispatch.send_to(component_id, message);
     }
 
     /// Send a message to a topic owner


### PR DESCRIPTION
## Summary

This PR improves the ergonomics of message passing in the component system by adding convenient send methods to the Context API. Components can now easily send messages to themselves without needing to track their own ID.

## Changes

### API Additions
- Added `Context::send(message)` - sends a message to the current component (self)
- Added `Context::send_to(id, message)` - sends a message to a specific component

### API Changes
- Renamed `Dispatcher::send()` to `Dispatcher::send_to()` for clarity and consistency
- Updated internal handler methods to use the renamed `send_to` method

## Motivation

Previously, if a component needed to send a message to itself (for deferred processing, state transitions, etc.), it would need to either:
1. Access `self.dispatch.send(self.current_component_id.clone(), message)` directly
2. Create and immediately invoke a handler: `ctx.handler(msg)()`

With these changes, components can now simply use `ctx.send(message)` for self-messaging, making the API more intuitive and consistent.

## Usage Examples

### Before
```rust
// Sending to self was awkward
let id = ctx.id().clone();
ctx.dispatch.send(id, Box::new(MyMessage));

// Or using handler workaround
ctx.handler(MyMessage)();
```

### After
```rust
// Send to self
ctx.send(Box::new(MyMessage));

// Send to another component
ctx.send_to(other_id, Box::new(MyMessage));

// Send to topic (unchanged)
ctx.send_to_topic("my_topic", Box::new(MyMessage));
```

## Testing

- All existing examples compile and run without modifications
- The renamed internal methods maintain backward compatibility through the new public API
