### PR TITLE
refactor(effects): rename macro to singular form and make default feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ RxTUI supports async background tasks through its effects system. Effects are pe
 
 ### Quick Example with #[component] Macro
 
-The easiest way to use effects is with the `#[component]` and `#[effects]` macros:
+The easiest way to use effects is with the `#[component]` and `#[effect]` macros:
 
 ```rust
 use rxtui::prelude::*;
@@ -663,7 +663,7 @@ use std::time::Duration;
 #[derive(Component, Clone)]
 struct WeatherWidget;
 
-#[component]  // Automatically collects all #[effects] methods
+#[component]  // Automatically collects all #[effect] methods
 impl WeatherWidget {
     #[update]
     fn update(&self, ctx: &Context, msg: WeatherMsg, mut state: WeatherState) -> Action {
@@ -695,7 +695,7 @@ impl WeatherWidget {
     }
 
     // This async method will be automatically collected as an effect
-    #[effects]
+    #[effect]
     async fn fetch_weather(&self, ctx: &Context) {
         loop {
             // Fetch weather data from API
@@ -710,7 +710,7 @@ impl WeatherWidget {
     }
 
     // Can have multiple effects
-    #[effects]
+    #[effect]
     async fn handle_user_refresh(&self, ctx: &Context, state: WeatherState) {
         // Effects can access state via optional parameter
         if state.auto_refresh {
@@ -765,7 +765,7 @@ The `examples/` directory contains full applications:
 - **simple.rs** - Interactive color picker showing event handling
 - **demo.rs** - Multi-page showcase of all features
 - **components.rs** - Topic-based component communication with multiple counters
-- **timer.rs** - Timer with async effects demonstrating the `#[component]` and `#[effects]` macros
+- **timer.rs** - Timer with async effects demonstrating the `#[component]` and `#[effect]` macros
 
 Each example is thoroughly commented and demonstrates best practices.
 

--- a/rxtui/Cargo.toml
+++ b/rxtui/Cargo.toml
@@ -16,7 +16,7 @@ name = "rxtui"
 path = "lib/lib.rs"
 
 [features]
-default = []
+default = ["effects"]
 effects = ["tokio", "futures"]
 
 [dependencies]

--- a/rxtui/examples/timer.rs
+++ b/rxtui/examples/timer.rs
@@ -1,6 +1,6 @@
 //! Simple timer example with effects
 //!
-//! Run with: cargo run --example timer --features effects
+//! Run with: cargo run --example timer
 
 use rxtui::prelude::*;
 
@@ -76,8 +76,7 @@ impl Timer {
         }
     }
 
-    #[cfg(feature = "effects")]
-    #[effects]
+    #[effect]
     async fn tick_timer(&self, ctx: &Context) {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -91,13 +90,6 @@ impl Timer {
 //--------------------------------------------------------------------------------------------------
 
 fn main() -> std::io::Result<()> {
-    #[cfg(not(feature = "effects"))]
-    {
-        eprintln!("This example requires the 'effects' feature.");
-        eprintln!("Run with: cargo run --example timer --features effects");
-        return Ok(());
-    }
-
     let mut app = App::new()?;
     app.run(Timer)?;
     Ok(())

--- a/rxtui/lib/component.rs
+++ b/rxtui/lib/component.rs
@@ -140,7 +140,7 @@ where
 ///
 /// # With Async Effects (using #[component] macro)
 ///
-/// The `#[component]` macro automatically collects all `#[effects]` methods:
+/// The `#[component]` macro automatically collects all `#[effect]` methods:
 ///
 /// ```ignore
 /// use rxtui::prelude::*;
@@ -175,7 +175,7 @@ where
 ///     }
 ///
 ///     // Mark async methods as effects - they'll be auto-collected
-///     #[effects]
+///     #[effect]
 ///     async fn tick_timer(&self, ctx: &Context) {
 ///         loop {
 ///             tokio::time::sleep(Duration::from_secs(1)).await;
@@ -184,7 +184,7 @@ where
 ///     }
 ///
 ///     // Can have multiple effects, with optional state access
-///     #[effects]
+///     #[effect]
 ///     async fn monitor_state(&self, ctx: &Context, state: TimerState) {
 ///         // State is automatically fetched via ctx.get_state()
 ///         if state.seconds > 60 {
@@ -232,15 +232,15 @@ pub trait Component: 'static {
     /// Effects are async tasks that run outside the main event loop.
     /// They are spawned when the component mounts and cancelled when it unmounts.
     ///
-    /// # Using the #[component] and #[effects] macros (Recommended)
+    /// # Using the #[component] and #[effect] macros (Recommended)
     ///
     /// The easiest way is to use the `#[component]` macro on your impl block
-    /// and mark async methods with `#[effects]`:
+    /// and mark async methods with `#[effect]`:
     ///
     /// ```ignore
     /// #[component]
     /// impl MyComponent {
-    ///     #[effects]
+    ///     #[effect]
     ///     async fn background_task(&self, ctx: &Context) {
     ///         // Async work here
     ///     }

--- a/rxtui/lib/effect/mod.rs
+++ b/rxtui/lib/effect/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! # Quick Start
 //!
-//! The easiest way to use effects is with the `#[component]` and `#[effects]` macros:
+//! The easiest way to use effects is with the `#[component]` and `#[effect]` macros:
 //!
 //! ```ignore
 //! use rxtui::prelude::*;
@@ -15,7 +15,7 @@
 //! #[derive(Component, Clone)]
 //! struct Timer;
 //!
-//! #[component]  // Automatically collects all #[effects] methods
+//! #[component]  // Automatically collects all #[effect] methods
 //! impl Timer {
 //!     #[update]
 //!     fn update(&self, ctx: &Context, msg: TimerMsg, mut state: TimerState) -> Action {
@@ -36,7 +36,7 @@
 //!         }
 //!     }
 //!
-//!     #[effects]
+//!     #[effect]
 //!     async fn tick(&self, ctx: &Context) {
 //!         loop {
 //!             tokio::time::sleep(Duration::from_secs(1)).await;
@@ -62,13 +62,13 @@
 //! ```ignore
 //! #[component]
 //! impl Dashboard {
-//!     #[effects]
+//!     #[effect]
 //!     async fn fetch_data(&self, ctx: &Context) {
 //!         let data = fetch_from_api().await;
 //!         ctx.send(DashboardMsg::DataLoaded(data));
 //!     }
 //!
-//!     #[effects]
+//!     #[effect]
 //!     async fn websocket_listener(&self, ctx: &Context) {
 //!         let mut ws = connect_websocket().await;
 //!         while let Some(msg) = ws.next().await {
@@ -76,7 +76,7 @@
 //!         }
 //!     }
 //!
-//!     #[effects]
+//!     #[effect]
 //!     async fn auto_refresh(&self, ctx: &Context) {
 //!         loop {
 //!             tokio::time::sleep(Duration::from_secs(30)).await;
@@ -91,7 +91,7 @@
 //! Effects can read component state by adding a state parameter:
 //!
 //! ```ignore
-//! #[effects]
+//! #[effect]
 //! async fn monitor(&self, ctx: &Context, state: AppState) {
 //!     // State is automatically fetched via ctx.get_state()
 //!     if state.threshold_exceeded() {
@@ -137,7 +137,7 @@
 //! also handle cancellation explicitly:
 //!
 //! ```ignore
-//! #[effects]
+//! #[effect]
 //! async fn cancellable_task(&self, ctx: &Context) {
 //!     let handle = spawn_cancellable_task();
 //!
@@ -155,7 +155,7 @@
 //! Always handle errors gracefully in effects:
 //!
 //! ```ignore
-//! #[effects]
+//! #[effect]
 //! async fn network_task(&self, ctx: &Context) {
 //!     match fetch_data().await {
 //!         Ok(data) => ctx.send(MyMsg::Success(data)),

--- a/rxtui/lib/lib.rs
+++ b/rxtui/lib/lib.rs
@@ -160,7 +160,7 @@ pub mod effect;
 #[doc(hidden)]
 pub use rxtui_macros::Component as ComponentMacro;
 #[cfg(feature = "effects")]
-pub use rxtui_macros::effects;
+pub use rxtui_macros::effect;
 pub use rxtui_macros::{component, update, view};
 
 pub use app::{App, Context, Dispatcher, RenderConfig, StateMap};

--- a/rxtui/lib/prelude.rs
+++ b/rxtui/lib/prelude.rs
@@ -24,7 +24,7 @@ pub use crate::ComponentMacro as Component;
 
 // Re-export attribute macros
 #[cfg(feature = "effects")]
-pub use crate::effects;
+pub use crate::effect;
 pub use crate::{component, update, view};
 
 // UI elements


### PR DESCRIPTION
## Summary

This PR renames the `#[effects]` macro to `#[effect]` for consistency with other singular attribute macros in the codebase (`#[update]`, `#[view]`, `#[component]`). Additionally, the effects feature is now enabled by default with an opt-out approach, removing the need for feature flag conditionals in examples.

## Changes

- **Macro Renaming**: Changed `#[effects]` to `#[effect]` throughout the codebase
  - Updated macro definition in `rxtui-macros/src/lib.rs`
  - Updated all documentation examples to use the new name
  - Updated the timer example to use `#[effect]`

- **Feature Flag Changes**: Made effects a default feature
  - Modified `Cargo.toml` to include effects in default features
  - Removed `#[cfg(feature = "effects")]` conditionals from timer example
  - Simplified example code by removing feature flag checks

## Motivation

1. **Naming Consistency**: The singular form `#[effect]` aligns better with other attribute macros in the framework and follows Rust conventions where attributes typically use singular forms

2. **Better Developer Experience**: Making effects a default feature removes friction for developers who want to use async functionality, while still allowing opt-out for size-constrained environments

## Testing

- Timer example runs successfully with the renamed macro
- All existing tests pass with the changes
