### PR TITLE
feat(app): add flexible poll duration settings

### DIFF
--- a/rxtui/lib/app/config.rs
+++ b/rxtui/lib/app/config.rs
@@ -13,6 +13,10 @@ pub struct RenderConfig {
 
     /// Enable cell-level diffing (default: true)
     pub cell_diffing: bool,
+
+    /// Event polling duration in milliseconds (default: 100ms)
+    /// Lower values make the app more responsive but use more CPU
+    pub poll_duration_ms: u64,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -26,6 +30,7 @@ impl RenderConfig {
             double_buffering: false,
             terminal_optimizations: false,
             cell_diffing: false,
+            poll_duration_ms: 100,
         }
     }
 }
@@ -40,6 +45,7 @@ impl Default for RenderConfig {
             double_buffering: true,
             terminal_optimizations: true,
             cell_diffing: true,
+            poll_duration_ms: 100,
         }
     }
 }

--- a/rxtui/lib/app/core.rs
+++ b/rxtui/lib/app/core.rs
@@ -218,6 +218,28 @@ impl App {
         self
     }
 
+    /// Sets the event polling duration in milliseconds.
+    /// Lower values make the app more responsive but use more CPU.
+    /// Default is 100ms.
+    pub fn poll_duration(mut self, duration_ms: u64) -> Self {
+        self.config.poll_duration_ms = duration_ms;
+        self
+    }
+
+    /// Sets the app to use a fast polling rate (10ms).
+    /// This makes the app very responsive but uses more CPU.
+    pub fn fast_polling(mut self) -> Self {
+        self.config.poll_duration_ms = 10;
+        self
+    }
+
+    /// Sets the app to use a slow polling rate (500ms).
+    /// This reduces CPU usage but may feel less responsive.
+    pub fn slow_polling(mut self) -> Self {
+        self.config.poll_duration_ms = 500;
+        self
+    }
+
     /// Main event loop using component-based architecture.
     ///
     /// Manages component state through messages and actions,
@@ -350,8 +372,10 @@ impl App {
                 needs_render = false;
             }
 
-            // Poll for events with a shorter timeout since we're not rendering constantly
-            if event::poll(std::time::Duration::from_millis(100))? {
+            // Poll for events with configurable timeout
+            if event::poll(std::time::Duration::from_millis(
+                self.config.poll_duration_ms,
+            ))? {
                 match event::read()? {
                     Event::Key(key_event) => {
                         handle_key_event(&self.vdom, key_event);


### PR DESCRIPTION
## Summary

Adds configurable event polling duration to the rxtui framework, allowing developers to balance between application responsiveness and CPU usage through builder methods.

## Changes

- Added `poll_duration_ms` field to `RenderConfig` with a default of 100ms
- Implemented three builder methods on `App`:
  - `poll_duration(duration_ms: u64)` - Set custom poll duration in milliseconds
  - `fast_polling()` - Preset for 10ms polling (high responsiveness, higher CPU usage)
  - `slow_polling()` - Preset for 500ms polling (lower CPU usage, less responsive)
- Updated the event loop to use the configured poll duration instead of hardcoded 100ms

## Usage

```rust
// Default polling (100ms)
let app = App::new()?;

// Fast polling for high responsiveness
let app = App::new()?.fast_polling();

// Slow polling for reduced CPU usage
let app = App::new()?.slow_polling();

// Custom duration
let app = App::new()?.poll_duration(50);
```

## Motivation

Previously, the event polling duration was hardcoded to 100ms. This change provides flexibility for applications with different performance requirements:
- Games or real-time applications can use fast polling for immediate input response
- Dashboard or monitoring apps can use slow polling to reduce CPU usage
- Custom values allow fine-tuning for specific use cases

## Testing

The changes maintain backward compatibility with existing code. The default behavior (100ms polling) remains unchanged unless explicitly configured.