### PR TITLE
feat(macros): add lowercase key value support for ergonomic syntax

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -791,10 +791,10 @@ color: (optional_color)!
 |--------|-------------|
 | `@click: handler` | Mouse click |
 | `@char('x'): handler` | Character key |
-| `@key(Enter): handler` | Special key |
+| `@key(enter): handler` | Special key |
 | `@key(Char('-')): handler` | Character via Key enum |
 | `@char_global('q'): handler` | Global character |
-| `@key_global(Esc): handler` | Global special key |
+| `@key_global(esc): handler` | Global special key |
 | `@focus: handler` | Gained focus |
 | `@blur: handler` | Lost focus |
 | `@any_char: \|ch\| handler` | Any character |

--- a/DOCS.md
+++ b/DOCS.md
@@ -50,7 +50,7 @@ impl HelloWorld {
             div(bg: blue, pad: 2) [
                 text("Hello, Terminal!", color: white, bold),
                 text("Press Esc to exit", color: white),
-                @key_global(Esc): ctx.handler(())
+                @key_global(esc): ctx.handler(())
             ]
         }
     }
@@ -96,7 +96,7 @@ The `node!` macro is how you actually build your UI. It gives you a clean, decla
 #[view]
 fn view(&self, ctx: &Context, state: AppState) -> Node {
     node! {
-        div(bg: blue, pad: 2, border: white, @key_global(Esc): ctx.handler(Msg::Exit)) [
+        div(bg: blue, pad: 2, border: white, @key_global(esc): ctx.handler(Msg::Exit)) [
             text(format!("Count: {}", state.count), color: yellow),
 
             hstack(gap: 2, @click: ctx.handler(Msg::Increment)) [
@@ -277,7 +277,7 @@ The `node!` macro provides a declarative syntax for building UI trees, inspired 
 ```rust
 node! {
     // Root element (usually div)
-    div(properties, @click: handler, @key(Enter): handler) [
+    div(properties, @click: handler, @key(enter): handler) [
         // Children
         text("content", properties),
         div(properties) [
@@ -492,14 +492,14 @@ node! {
         @click: ctx.handler(Msg::Clicked),
         // Keyboard events (requires focus)
         @char('a'): ctx.handler(Msg::KeyA),
-        @key(Enter): ctx.handler(Msg::Enter),
+        @key(enter): ctx.handler(Msg::Enter),
         @key(Char('-')): ctx.handler(Msg::Minus),
         // Focus events
         @focus: ctx.handler(Msg::Focused),
         @blur: ctx.handler(Msg::Blurred),
         // Global events (work without focus)
         @char_global('q'): ctx.handler(Msg::Quit),
-        @key_global(Esc): ctx.handler(Msg::Exit),
+        @key_global(esc): ctx.handler(Msg::Exit),
         // Any character handler
         @any_char: |ch| ctx.handler(Msg::Typed(ch))
     ) [
@@ -916,8 +916,8 @@ node! {
         @click: ctx.handler(Msg::Clicked),
         // Keyboard
         @char('a'): ctx.handler(Msg::PressedA),
-        @key(Enter): ctx.handler(Msg::Confirmed),
-        @key(Backspace): ctx.handler(Msg::Delete),
+        @key(enter): ctx.handler(Msg::Confirmed),
+        @key(backspace): ctx.handler(Msg::Delete),
         // Focus
         @focus: ctx.handler(Msg::GainedFocus),
         @blur: ctx.handler(Msg::LostFocus)
@@ -936,7 +936,7 @@ node! {
     div [
         // Application-wide shortcuts
         @char_global('q'): ctx.handler(Msg::Quit),
-        @key_global(Esc): ctx.handler(Msg::Cancel),
+        @key_global(esc): ctx.handler(Msg::Cancel),
         @char_global('/'): ctx.handler(Msg::Search)
     ]
 }
@@ -1114,7 +1114,7 @@ impl CounterApp {
     #[view]
     fn view(&self, ctx: &Context, state: State) -> Node {
         node! {
-            div(bg: black, pad: 2, @char_global('q'): ctx.handler(Msg::Exit), @key_global(Esc): ctx.handler(Msg::Exit)) [
+            div(bg: black, pad: 2, @char_global('q'): ctx.handler(Msg::Exit), @key_global(esc): ctx.handler(Msg::Exit)) [
                 text(format!("Count: {}", state.count), color: white, bold),
 
                 hstack(gap: 2) [

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -703,7 +703,7 @@ Provides ergonomic APIs for building UIs:
 Declarative syntax for building UI trees:
 ```rust
 node! {
-    div(bg: blue, pad: 2, @click: ctx.handler(Msg::Click), @key(Enter): ctx.handler(Msg::Enter)) [
+    div(bg: blue, pad: 2, @click: ctx.handler(Msg::Click), @key(enter): ctx.handler(Msg::Enter)) [
         text("Hello", color: white),
         div(border: white) [
             text("Nested")

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -37,7 +37,7 @@ impl MyComponent {
             div(bg: black, pad: 2) [
                 text(format!("Count: {}", state.counter)),
                 @click: ctx.handler(MyMsg::Click),
-                @key_global(Esc): ctx.handler(MyMsg::Exit)
+                @key_global(esc): ctx.handler(MyMsg::Exit)
             ]
         }
     }
@@ -179,12 +179,12 @@ div(
     @click: handler,
     // Keyboard (requires focus)
     @char('a'): handler,
-    @key(Enter): handler,
-    @key(Backspace): handler,
+    @key(enter): handler,
+    @key(backspace): handler,
     @char('-'): handler,  // For character keys, use @char
     // Global (no focus needed)
     @char_global('q'): handler,
-    @key_global(Esc): handler,
+    @key_global(esc): handler,
     // Focus
     @focus: handler,
     @blur: handler,

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ impl Counter {
     #[view]
     fn view(&self, ctx: &Context, count: i32) -> Node {
         node! {
-            div(@key_global(Up): ctx.handler("inc"), @key_global(Down): ctx.handler("dec"), @key_global(Esc): ctx.handler("exit")) [
+            div(@key_global(up): ctx.handler("inc"), @key_global(down): ctx.handler("dec"), @key_global(esc): ctx.handler("exit")) [
                 text(format!("Count: {count}"), color: white, bold),
                 text("use ↑/↓ to change, esc to exit", color: bright_black)
             ]

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -26,7 +26,7 @@ impl HelloWorld {
     #[view]
     fn view(&self, ctx: &Context) -> Node {
         node! {
-            div(bg: blue, pad: 2, @key_global(Esc): ctx.handler(())) [
+            div(bg: blue, pad: 2, @key_global(esc): ctx.handler(())) [
                 text("Hello, RxTUI!", color: white, bold),
                 text("Press Esc to exit", color: white)
             ]
@@ -242,13 +242,13 @@ fn view(&self, ctx: &Context, state: AppState) -> Node {
                             .border(Color::Yellow)
                     }),
                     @click: ctx.handler(AppMsg::ButtonClicked("One".into())),
-                    @key(Enter): ctx.handler(AppMsg::ButtonClicked("One".into()))
+                    @key(enter): ctx.handler(AppMsg::ButtonClicked("One".into()))
                 ) [
                     text("Button 1")
                 ],
 
                 // Another button
-                div(border: white, pad: 1, focusable, @click: ctx.handler(AppMsg::ButtonClicked("Two".into())), @key(Enter): ctx.handler(AppMsg::ButtonClicked("Two".into()))) [
+                div(border: white, pad: 1, focusable, @click: ctx.handler(AppMsg::ButtonClicked("Two".into())), @key(enter): ctx.handler(AppMsg::ButtonClicked("Two".into()))) [
                     text("Button 2")
                 ]
             ],
@@ -305,7 +305,7 @@ impl Form {
     #[view]
     fn view(&self, ctx: &Context, state: FormState) -> Node {
         node! {
-            div(pad: 2, @key_global(Esc): ctx.handler(FormMsg::Exit)) [
+            div(pad: 2, @key_global(esc): ctx.handler(FormMsg::Exit)) [
                 text("User Form", bold, color: cyan),
 
                 // Text inputs
@@ -336,7 +336,7 @@ impl Form {
                 spacer(2),
 
                 // Submit button
-                div(border: green, pad: 1, focusable, @click: ctx.handler(FormMsg::Submit), @key(Enter): ctx.handler(FormMsg::Submit)) [
+                div(border: green, pad: 1, focusable, @click: ctx.handler(FormMsg::Submit), @key(enter): ctx.handler(FormMsg::Submit)) [
                     text("Submit")
                 ],
 
@@ -635,7 +635,7 @@ impl TodoApp {
         let active_count = state.todos.iter().filter(|t| !t.completed).count();
 
         node! {
-            div(bg: black, pad: 2, @key_global(Esc): ctx.handler(TodoMsg::Exit)) [
+            div(bg: black, pad: 2, @key_global(esc): ctx.handler(TodoMsg::Exit)) [
                 // Header
                 div(bg: blue, pad: 1, w_pct: 1.0) [
                     text("TODO LIST", color: white, bold)

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -16,7 +16,7 @@ impl Counter {
     #[view]
     fn view(&self, ctx: &Context, count: i32) -> Node {
         node! {
-            div(@key_global(Up): ctx.handler("inc"), @key_global(Down): ctx.handler("dec"), @key_global(Esc): ctx.handler("exit")) [
+            div(@key_global(up): ctx.handler("inc"), @key_global(down): ctx.handler("dec"), @key_global(esc): ctx.handler("exit")) [
                 text(format!("Count: {count}"), color: white, bold),
                 text("use ↑/↓ to change, esc to exit", color: bright_black)
             ]

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -54,7 +54,7 @@ impl Form {
     #[view]
     fn view(&self, ctx: &Context, state: FormState) -> Node {
         node! {
-            div(bg: black, pad: 2, w_pct: 1.0, @key(Esc): ctx.handler(Msg::Exit), @char('c'): ctx.handler(Msg::Clear), @char('C'): ctx.handler(Msg::Clear)) [
+            div(bg: black, pad: 2, w_pct: 1.0, @key(esc): ctx.handler(Msg::Exit), @char('c'): ctx.handler(Msg::Clear), @char('C'): ctx.handler(Msg::Clear)) [
                 // Title
                 text("Form Example with Callbacks", color: cyan, bold),
                 spacer(1),

--- a/examples/rxtui.rs
+++ b/examples/rxtui.rs
@@ -7,7 +7,7 @@ impl RxTuiLogo {
     #[view]
     fn view(&self, ctx: &Context) -> Node {
         node! {
-            div(bg: black, w_pct: 1.0, h_pct: 1.0, dir: vertical, pad: 2, gap: 1, @char_global('q'): ctx.handler(()), @key_global(Esc): ctx.handler(())) [
+            div(bg: black, w_pct: 1.0, h_pct: 1.0, dir: vertical, pad: 2, gap: 1, @char_global('q'): ctx.handler(()), @key_global(esc): ctx.handler(())) [
                 vstack(bg: black) [
                     text("██████    ██    ██  ██████████  ██    ██  ██", color: "#8B4FB3"),
                     text("██████    ██    ██  ██████████  ██    ██  ██", color: "#B06FA8"),

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -25,7 +25,7 @@ impl Spinner {
         let frame = frames[state];
 
         node! {
-            div(bg: black, pad: 2, @key(Esc): ctx.handler(Msg::Exit)) [
+            div(bg: black, pad: 2, @key(esc): ctx.handler(Msg::Exit)) [
                 text(format!("Spinner: {frame}"), color: white, bold),
                 text("press esc to exit", color: bright_black)
             ]

--- a/examples/stopwatch.rs
+++ b/examples/stopwatch.rs
@@ -20,7 +20,7 @@ impl Stopwatch {
         let centiseconds = (state % 1000) / 10;
 
         node! {
-            div(bg: black, pad: 2, @key(Esc): ctx.handler(false)) [
+            div(bg: black, pad: 2, @key(esc): ctx.handler(false)) [
                 text(format!("Elapsed: {}.{:02}s", seconds, centiseconds), color: white, bold),
                 text("press esc to exit", color: bright_black)
             ]

--- a/rxtui/examples/components.rs
+++ b/rxtui/examples/components.rs
@@ -105,8 +105,8 @@ impl Counter {
                 }),
                 @key(Char('-')): ctx.handler(CounterMsg::Decrement),
                 @key(Char('+')): ctx.handler(CounterMsg::Increment),
-                @key(Down): ctx.handler(CounterMsg::Decrement),
-                @key(Up): ctx.handler(CounterMsg::Increment)
+                @key(down): ctx.handler(CounterMsg::Decrement),
+                @key(up): ctx.handler(CounterMsg::Increment)
             ) [
                 text(&self.label, color: white),
                 text(format!("Count: {}", state.count), color: bright_white),
@@ -189,7 +189,7 @@ impl Dashboard {
                 ],
 
                 @char_global('q'): ctx.handler(DashboardMsg::Exit),
-                @key_global(Esc): ctx.handler(DashboardMsg::Exit)
+                @key_global(esc): ctx.handler(DashboardMsg::Exit)
             ]
         }
     }

--- a/rxtui/examples/demo.rs
+++ b/rxtui/examples/demo.rs
@@ -89,7 +89,7 @@ impl Demo {
             div(
                 bg: black, dir: vertical, pad: 1, w_pct: 1.0, h_pct: 1.0,
                 @char_global('q'): ctx.handler(DemoMessage::Exit),
-                @key_global(Esc): ctx.handler(DemoMessage::Exit),
+                @key_global(esc): ctx.handler(DemoMessage::Exit),
                 @char('1'): ctx.handler(DemoMessage::SetPage(1)),
                 @char('2'): ctx.handler(DemoMessage::SetPage(2)),
                 @char('3'): ctx.handler(DemoMessage::SetPage(3)),
@@ -105,8 +105,8 @@ impl Demo {
                 @char('['): ctx.handler(DemoMessage::SetPage(13)),
                 @char(']'): ctx.handler(DemoMessage::SetPage(14)),
                 @char('\\'): ctx.handler(DemoMessage::SetPage(15)),
-                @key(Right): ctx.handler(DemoMessage::NextPage),
-                @key(Left): ctx.handler(DemoMessage::PrevPage)
+                @key(right): ctx.handler(DemoMessage::NextPage),
+                @key(left): ctx.handler(DemoMessage::PrevPage)
             ) [
                 // Header
                 div(bg: bright_black, dir: horizontal, pad: 1, w_pct: 1.0, h: 3) [

--- a/rxtui/examples/demo_pages/page12_focus.rs
+++ b/rxtui/examples/demo_pages/page12_focus.rs
@@ -135,7 +135,7 @@ impl FocusButton {
                         .padding(Spacing::all(1))
                 }),
                 @click: ctx.handler(FocusButtonMsg::Increment),
-                @key(Enter): ctx.handler(FocusButtonMsg::Increment),
+                @key(enter): ctx.handler(FocusButtonMsg::Increment),
                 @focus: ctx.handler(FocusButtonMsg::Focused),
                 @blur: ctx.handler(FocusButtonMsg::Blurred)
             ) [

--- a/rxtui/examples/simple.rs
+++ b/rxtui/examples/simple.rs
@@ -71,7 +71,7 @@ impl ColorDemo {
     #[view]
     fn view(&self, ctx: &Context, state: ColorDemoState) -> Node {
         node! {
-            div(bg: black, dir: vertical, pad: 1, @char_global('q'): ctx.handler(ColorDemoMsg::Exit), @key_global(Esc): ctx.handler(ColorDemoMsg::Exit)) [
+            div(bg: black, dir: vertical, pad: 1, @char_global('q'): ctx.handler(ColorDemoMsg::Exit), @key_global(esc): ctx.handler(ColorDemoMsg::Exit)) [
                 // Title bar
                 hstack(bg: "#333333", pad: 1, w: 80, h: 3) [
                     text("Radical TUI - Color Demo", color: "#00DDFF"),

--- a/rxtui/examples/timer.rs
+++ b/rxtui/examples/timer.rs
@@ -55,7 +55,7 @@ impl Timer {
         let status = if state.running { "Running" } else { "Paused" };
 
         node! {
-            div(bg: black, dir: vertical, pad: 2, h: 12, gap: 2, @key(Char(' ')): ctx.handler(Msg::Toggle), @key(Char('r')): ctx.handler(Msg::Reset), @key(Char('q')): ctx.handler(Msg::Exit), @key(Esc): ctx.handler(Msg::Exit)) [
+            div(bg: black, dir: vertical, pad: 2, h: 12, gap: 2, @key(Char(' ')): ctx.handler(Msg::Toggle), @key(Char('r')): ctx.handler(Msg::Reset), @key(Char('q')): ctx.handler(Msg::Exit), @key(esc): ctx.handler(Msg::Exit)) [
                 // Timer display
                 div(bg: "#1a1a1a", border: white, pad: 1, w_pct: 1.0) [
                     div(dir: vertical) [

--- a/rxtui/lib/macros/internal.rs
+++ b/rxtui/lib/macros/internal.rs
@@ -171,3 +171,189 @@ macro_rules! position_value {
         $pos
     };
 }
+
+/// Converts key values to Key enum
+/// Supports lowercase/snake_case names for ergonomics
+#[doc(hidden)]
+#[macro_export]
+macro_rules! key_value {
+    // Special keys (lowercase)
+    (esc) => {
+        $crate::Key::Esc
+    };
+    (enter) => {
+        $crate::Key::Enter
+    };
+    (tab) => {
+        $crate::Key::Tab
+    };
+    (backtab) => {
+        $crate::Key::BackTab
+    };
+    (back_tab) => {
+        $crate::Key::BackTab
+    };
+    (backspace) => {
+        $crate::Key::Backspace
+    };
+    (delete) => {
+        $crate::Key::Delete
+    };
+
+    // Arrow keys (lowercase)
+    (up) => {
+        $crate::Key::Up
+    };
+    (down) => {
+        $crate::Key::Down
+    };
+    (left) => {
+        $crate::Key::Left
+    };
+    (right) => {
+        $crate::Key::Right
+    };
+
+    // Navigation keys (snake_case)
+    (page_up) => {
+        $crate::Key::PageUp
+    };
+    (pageup) => {
+        $crate::Key::PageUp
+    };
+    (page_down) => {
+        $crate::Key::PageDown
+    };
+    (pagedown) => {
+        $crate::Key::PageDown
+    };
+    (home) => {
+        $crate::Key::Home
+    };
+    (end) => {
+        $crate::Key::End
+    };
+
+    // Function keys (lowercase)
+    (f1) => {
+        $crate::Key::F1
+    };
+    (f2) => {
+        $crate::Key::F2
+    };
+    (f3) => {
+        $crate::Key::F3
+    };
+    (f4) => {
+        $crate::Key::F4
+    };
+    (f5) => {
+        $crate::Key::F5
+    };
+    (f6) => {
+        $crate::Key::F6
+    };
+    (f7) => {
+        $crate::Key::F7
+    };
+    (f8) => {
+        $crate::Key::F8
+    };
+    (f9) => {
+        $crate::Key::F9
+    };
+    (f10) => {
+        $crate::Key::F10
+    };
+    (f11) => {
+        $crate::Key::F11
+    };
+    (f12) => {
+        $crate::Key::F12
+    };
+
+    // Backwards compatibility - support CamelCase variants
+    (Esc) => {
+        $crate::Key::Esc
+    };
+    (Enter) => {
+        $crate::Key::Enter
+    };
+    (Tab) => {
+        $crate::Key::Tab
+    };
+    (BackTab) => {
+        $crate::Key::BackTab
+    };
+    (Backspace) => {
+        $crate::Key::Backspace
+    };
+    (Delete) => {
+        $crate::Key::Delete
+    };
+    (Up) => {
+        $crate::Key::Up
+    };
+    (Down) => {
+        $crate::Key::Down
+    };
+    (Left) => {
+        $crate::Key::Left
+    };
+    (Right) => {
+        $crate::Key::Right
+    };
+    (PageUp) => {
+        $crate::Key::PageUp
+    };
+    (PageDown) => {
+        $crate::Key::PageDown
+    };
+    (Home) => {
+        $crate::Key::Home
+    };
+    (End) => {
+        $crate::Key::End
+    };
+    (F1) => {
+        $crate::Key::F1
+    };
+    (F2) => {
+        $crate::Key::F2
+    };
+    (F3) => {
+        $crate::Key::F3
+    };
+    (F4) => {
+        $crate::Key::F4
+    };
+    (F5) => {
+        $crate::Key::F5
+    };
+    (F6) => {
+        $crate::Key::F6
+    };
+    (F7) => {
+        $crate::Key::F7
+    };
+    (F8) => {
+        $crate::Key::F8
+    };
+    (F9) => {
+        $crate::Key::F9
+    };
+    (F10) => {
+        $crate::Key::F10
+    };
+    (F11) => {
+        $crate::Key::F11
+    };
+    (F12) => {
+        $crate::Key::F12
+    };
+
+    // Any other expression - pass through
+    ($key:expr) => {
+        $key
+    };
+}

--- a/rxtui/lib/macros/mod.rs
+++ b/rxtui/lib/macros/mod.rs
@@ -61,9 +61,9 @@
 //! Events use the `@` prefix:
 //! - `@click: handler` - Mouse click
 //! - `@char('q'): handler` - Character key
-//! - `@key(Enter): handler` - Special key
+//! - `@key(enter): handler` - Special key
 //! - `@char_global('q'): handler` - Global character
-//! - `@key_global(Esc): handler` - Global key
+//! - `@key_global(esc): handler` - Global key
 //! - `@focus: handler` - Focus gained
 //! - `@blur: handler` - Focus lost
 

--- a/rxtui/lib/macros/node.rs
+++ b/rxtui/lib/macros/node.rs
@@ -228,14 +228,14 @@
 /// ## Event Handlers
 /// ```ignore
 /// node! {
-///     div(bg: black, @char_global('q'): ctx.handler(Msg::Quit), @key_global(Esc): ctx.handler(Msg::Exit)) [
+///     div(bg: black, @char_global('q'): ctx.handler(Msg::Quit), @key_global(esc): ctx.handler(Msg::Exit)) [
 ///         // Click handler
 ///         container(bg: blue, focusable, @click: ctx.handler(Msg::Clicked)) [
 ///             text("Click me", color: white)
 ///         ],
 ///
 ///         // Keyboard handlers
-///         container(focusable, @char('a'): ctx.handler(Msg::KeyA), @key(Enter): ctx.handler(Msg::Enter), @key(Backspace): ctx.handler(Msg::Back)) [
+///         container(focusable, @char('a'): ctx.handler(Msg::KeyA), @key(enter): ctx.handler(Msg::Enter), @key(backspace): ctx.handler(Msg::Back)) [
 ///             text("Press keys here")
 ///         ],
 ///
@@ -370,10 +370,10 @@
 /// |---------|-------------|---------|
 /// | `@click` | Mouse click | `@click: handler` |
 /// | `@char(c)` | Character key press | `@char('a'): handler` |
-/// | `@key(k)` | Special key press | `@key(Enter): handler` |
+/// | `@key(k)` | Special key press | `@key(enter): handler` |
 /// | `@key(Char(c))` | Character in key enum | `@key(Char('-')): handler` |
 /// | `@char_global(c)` | Global character key | `@char_global('q'): handler` |
-/// | `@key_global(k)` | Global special key | `@key_global(Esc): handler` |
+/// | `@key_global(k)` | Global special key | `@key_global(esc): handler` |
 /// | `@focus` | Gained focus | `@focus: handler` |
 /// | `@blur` | Lost focus | `@blur: handler` |
 /// | `@any_char` | Any character typed | `@any_char: \|c\| handler(c)` |
@@ -1217,21 +1217,21 @@ macro_rules! tui_apply_props {
     }};
 
     // @key handler
-    ($container:expr, @key($key:ident): $handler:expr, $($rest:tt)*) => {{
-        let c = $container.on_key($crate::Key::$key, $handler);
+    ($container:expr, @key($key:tt): $handler:expr, $($rest:tt)*) => {{
+        let c = $container.on_key($crate::key_value!($key), $handler);
         $crate::tui_apply_props!(c, $($rest)*)
     }};
-    ($container:expr, @key($key:ident): $handler:expr) => {{
-        $container.on_key($crate::Key::$key, $handler)
+    ($container:expr, @key($key:tt): $handler:expr) => {{
+        $container.on_key($crate::key_value!($key), $handler)
     }};
 
     // @key_global handler
-    ($container:expr, @key_global($key:ident): $handler:expr, $($rest:tt)*) => {{
-        let c = $container.on_key_global($crate::Key::$key, $handler);
+    ($container:expr, @key_global($key:tt): $handler:expr, $($rest:tt)*) => {{
+        let c = $container.on_key_global($crate::key_value!($key), $handler);
         $crate::tui_apply_props!(c, $($rest)*)
     }};
-    ($container:expr, @key_global($key:ident): $handler:expr) => {{
-        $container.on_key_global($crate::Key::$key, $handler)
+    ($container:expr, @key_global($key:tt): $handler:expr) => {{
+        $container.on_key_global($crate::key_value!($key), $handler)
     }};
 
     // @focus handler


### PR DESCRIPTION
## Summary

This PR introduces lowercase key value support for the `@key` and `@key_global` event handlers, providing a more ergonomic and consistent API. Key names can now be written in lowercase (e.g., `esc`, `enter`, `up`) similar to how colors are handled, while maintaining backwards compatibility with CamelCase variants.

## Changes

### New Features
- Added `key_value!` macro in `internal.rs` that maps lowercase/snake_case key names to Key enum variants
- Support for multiple naming conventions:
  - Lowercase: `esc`, `enter`, `tab`, `backspace`, `delete`
  - Snake_case: `page_up`, `page_down`, `back_tab`
  - Alternative forms: `pageup`, `pagedown`, `backtab`
  - Function keys: `f1` through `f12`
  - Arrow keys: `up`, `down`, `left`, `right`
  - Navigation: `home`, `end`

### Implementation Details
- Modified `@key` and `@key_global` handler macros to accept `$key:tt` tokens instead of `$key:ident`
- Replaced direct `$crate::Key::$key` expansion with `$crate::key_value!($key)`
- Maintains full backwards compatibility with existing CamelCase syntax

### Migration
- **Before**: `@key(Esc)`, `@key_global(Enter)`, `@key(PageUp)`
- **After**: `@key(esc)`, `@key_global(enter)`, `@key(page_up)`
- Both styles work, but lowercase is now the preferred convention

### Files Updated
- Core macro system: `internal.rs`, `node.rs`
- All example files (15+ files) updated to use lowercase keys
- All documentation files updated with lowercase examples

## Motivation

1. **Consistency**: Aligns with the existing color value syntax where lowercase names are used (`color: red`, not `color: Red`)
2. **Ergonomics**: Lowercase is easier to type and more natural for property values
3. **User Expectations**: Most UI frameworks use lowercase for enum-like values in declarative syntax
4. **No Breaking Changes**: Full backwards compatibility ensures existing code continues to work

## Testing

- All examples compile and run successfully
- Pre-commit hooks pass (formatting, clippy, trailing whitespace)
- Both lowercase and CamelCase variants tested
