### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rxtui-workspace"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Microsandbox Team"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img width="450" alt="rxtui logo" src="https://github.com/user-attachments/assets/c2038f9f-5633-4617-bbfb-569a5a89697c" />
+  <img width="500" alt="rxtui logo" src="https://github.com/user-attachments/assets/ddd9e32e-e654-4acb-97e7-43b65a420eb0" />
 
   <br />
   <br />

--- a/rxtui/Cargo.toml
+++ b/rxtui/Cargo.toml
@@ -20,7 +20,7 @@ default = ["effects"]
 effects = ["tokio", "futures"]
 
 [dependencies]
-rxtui-macros = { version = "0.1.1", path = "../rxtui-macros" }
+rxtui-macros = { version = "0.1.2", path = "../rxtui-macros" }
 bitflags = "2.4"
 crossterm = "0.28"
 serde.workspace = true


### PR DESCRIPTION
## Summary

This PR bumps the project version from 0.1.1 to 0.1.2, preparing for a patch release that includes the recent flexbox alignment features and various improvements.

## Changes

- Update workspace version from 0.1.1 to 0.1.2
- Update workspace package version from 0.1.1 to 0.1.2
- Update rxtui-macros dependency version to 0.1.2

## Context

This patch release includes:
- Flexbox-style div alignment implementation (JustifyContent, AlignItems, AlignSelf)
- Improved form example with better UX
- Enhanced progressbar with peachy multi-stop gradient
- Comprehensive documentation updates
- Bug fixes and code refactoring

## Testing

- [x] Project builds successfully with updated versions
- [x] All examples run correctly
- [x] No version conflicts in dependencies
