### PR TITLE
refactor(effects): improve runtime handling and remove feature gates

### DIFF
--- a/rxtui-macros/src/lib.rs
+++ b/rxtui-macros/src/lib.rs
@@ -160,7 +160,6 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 
             // Use method resolution to call inherent __component_effects_impl if it exists,
             // otherwise fall back to the trait's default implementation (empty vec)
-            #[cfg(feature = "effects")]
             fn effects(&self, ctx: &rxtui::Context) -> Vec<rxtui::effect::Effect> {
                 use rxtui::providers::EffectsProvider;
                 self.__component_effects_impl(ctx)

--- a/rxtui/lib/component.rs
+++ b/rxtui/lib/component.rs
@@ -1,10 +1,8 @@
 use crate::app::Context;
+use crate::effect::Effect;
 use crate::node::Node;
 use std::any::Any;
 use std::fmt::Debug;
-
-#[cfg(feature = "effects")]
-use crate::effect::Effect;
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -286,7 +284,6 @@ pub trait Component: 'static {
     /// - **File watching**: Monitoring file system changes
     /// - **WebSocket connections**: Real-time communication
     /// - **Background calculations**: Heavy computations that shouldn't block UI
-    #[cfg(feature = "effects")]
     fn effects(&self, _ctx: &Context) -> Vec<Effect> {
         vec![]
     }

--- a/rxtui/lib/lib.rs
+++ b/rxtui/lib/lib.rs
@@ -386,9 +386,23 @@ pub mod macros;
 pub mod components;
 
 /// Async effects system for running background tasks
-/// Requires the "effects" feature flag
 #[cfg(feature = "effects")]
 pub mod effect;
+
+/// Stub effect module when effects feature is disabled
+#[cfg(not(feature = "effects"))]
+pub mod effect {
+    /// Stub Effect type when effects feature is disabled
+    #[derive(Debug, Clone)]
+    pub struct Effect;
+
+    impl Effect {
+        /// Create an empty effect vector
+        pub fn none() -> Vec<Self> {
+            vec![]
+        }
+    }
+}
 
 //--------------------------------------------------------------------------------------------------
 // Exports
@@ -397,9 +411,11 @@ pub mod effect;
 // Re-export the derive macro with the same name
 #[doc(hidden)]
 pub use rxtui_macros::Component as ComponentMacro;
+pub use rxtui_macros::{component, update, view};
+
+// Conditionally export the effect macro only when the feature is enabled
 #[cfg(feature = "effects")]
 pub use rxtui_macros::effect;
-pub use rxtui_macros::{component, update, view};
 
 pub use app::{App, Context};
 pub use bounds::Rect;

--- a/rxtui/lib/prelude.rs
+++ b/rxtui/lib/prelude.rs
@@ -14,8 +14,7 @@ pub use crate::app::{App, Context};
 // Component system
 pub use crate::component::{Action, Message, MessageExt, State};
 
-// Effects system (when feature is enabled)
-#[cfg(feature = "effects")]
+// Effects system
 pub use crate::effect::Effect;
 
 // Re-export both the trait and the derive macro

--- a/rxtui/lib/providers.rs
+++ b/rxtui/lib/providers.rs
@@ -3,10 +3,8 @@
 //! These traits use Rust's method resolution order where inherent methods shadow trait methods,
 //! allowing the macro system to provide default implementations that can be optionally overridden.
 
-use crate::{Action, Context, Message, Node};
-
-#[cfg(feature = "effects")]
 use crate::effect::Effect;
+use crate::{Action, Context, Message, Node};
 
 //--------------------------------------------------------------------------------------------------
 // Traits
@@ -51,7 +49,6 @@ pub trait ViewProvider {
 /// This uses Rust's method resolution order where inherent methods shadow trait methods,
 /// allowing #[component] to optionally override the default empty implementation.
 #[doc(hidden)]
-#[cfg(feature = "effects")]
 pub trait EffectsProvider {
     /// Internal method that returns empty effects by default.
     /// This is shadowed by an inherent method when #[component] is used.
@@ -67,6 +64,4 @@ pub trait EffectsProvider {
 // Blanket implementations provide the defaults for all types
 impl<T> UpdateProvider for T {}
 impl<T> ViewProvider for T {}
-
-#[cfg(feature = "effects")]
 impl<T> EffectsProvider for T {}


### PR DESCRIPTION
## Summary
- Refactored the effects runtime to detect and reuse existing tokio contexts
- Removed conditional compilation flags for the effects system
- Added stub Effect type for when the effects feature is disabled
- Simplified the API surface by making effects always available

This change prevents runtime panics when rxtui is used within existing async applications and provides a more consistent API that doesn't require conditional imports in user code.

## Changes
- **rxtui/lib/effect/runtime.rs**: Added RuntimeHandle enum to detect existing tokio runtime or create new one
- **rxtui/lib/lib.rs**: Added stub effect module with empty Effect type when feature is disabled
- **rxtui-macros/src/lib.rs**: Removed `#[cfg(feature = "effects")]` from Component macro
- **rxtui/lib/component.rs**: Removed conditional compilation, always import Effect
- **rxtui/lib/prelude.rs**: Always export Effect type from prelude
- **rxtui/lib/providers.rs**: Removed feature gates from EffectsProvider trait

## Test Plan
- Run `cargo test` to verify all existing tests pass
- Run `cargo test --all-features` to test with effects enabled
- Run `cargo test --no-default-features` to test with effects disabled
- Build examples: `cargo build --examples`
- Verify no runtime panics when using rxtui in async context