### PR TITLE
chore(release): bump version to 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rxtui-workspace"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 publish = false
 
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 authors = ["Microsandbox Team"]
 license = "Apache-2.0"

--- a/rxtui/Cargo.toml
+++ b/rxtui/Cargo.toml
@@ -20,7 +20,7 @@ default = ["effects"]
 effects = ["tokio", "futures"]
 
 [dependencies]
-rxtui-macros = { version = "0.1.3", path = "../rxtui-macros" }
+rxtui-macros = { version = "0.1.4", path = "../rxtui-macros" }
 bitflags = "2.4"
 crossterm = "0.28"
 serde.workspace = true


### PR DESCRIPTION
## Summary
- Increment patch version from 0.1.3 to 0.1.4 across the workspace
- Prepare for the next release with accumulated improvements and bug fixes
- Update workspace package version and internal dependency versions
- Ensure consistent versioning across all workspace members

## Changes
- Updated workspace.package.version in root Cargo.toml from 0.1.3 to 0.1.4
- Updated rxtui-workspace package version in root Cargo.toml
- Updated rxtui-macros dependency version in rxtui/Cargo.toml to match new version
- All workspace members inherit version from workspace configuration

## Test Plan
- Run `cargo build --all` to verify successful compilation
- Run `cargo check --all` to validate all workspace members
- Run `cargo test --all` to ensure all tests pass
- Run `cargo clippy --all` to check for any linting issues
- Verify that all workspace crates report version 0.1.4