### PR TITLE
chore(release): bump version to 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rxtui-workspace"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 authors = ["Microsandbox Team"]
 license = "Apache-2.0"

--- a/rxtui/Cargo.toml
+++ b/rxtui/Cargo.toml
@@ -20,7 +20,7 @@ default = ["effects"]
 effects = ["tokio", "futures"]
 
 [dependencies]
-rxtui-macros = { version = "0.1.4", path = "../rxtui-macros" }
+rxtui-macros = { version = "0.1.5", path = "../rxtui-macros" }
 bitflags = "2.4"
 crossterm = "0.28"
 serde.workspace = true


### PR DESCRIPTION
## Summary
- Increment patch version from 0.1.4 to 0.1.5 across the workspace
- Prepare for new release following the addition of spinner component
- Update all internal dependency versions to maintain consistency
- Release includes fixes for nested effects and new component features

## Changes
- Updated workspace version in root Cargo.toml from 0.1.4 to 0.1.5
- Updated rxtui-macros dependency version in rxtui/Cargo.toml to 0.1.5
- Version bump follows addition of spinner component with custom patterns (PR #32)
- Includes improvements to nested effects runtime handling from recent commits

## Test Plan
- Run `cargo build --all` to verify all workspace members compile
- Run `cargo test --all` to ensure all tests pass
- Run `cargo clippy --all` to check for any linting issues
- Verify the examples still work with `cargo run --example <example_name>`
- Check that version numbers are consistent across all workspace members