### PR TITLE
feat(components): add clear_on_submit option to TextInput

### DIFF
--- a/examples/textinput.rs
+++ b/examples/textinput.rs
@@ -68,9 +68,9 @@ impl TextInputTest {
                     if state.search_history.len() > 5 {
                         state.search_history.remove(0);
                     }
-                    let submitted = state.search_value.clone();
-                    state.search_value.clear();
-                    state.last_action = format!("Search submitted: '{}'", submitted);
+                    state.last_action = format!("Search submitted: '{}'", state.search_value);
+                    // Note: input will be cleared automatically by clear_on_submit flag
+                    // The SearchChanged handler will receive empty string and update state.search_value
                 } else {
                     state.last_action = "Search submitted but was empty".to_string();
                 }
@@ -161,6 +161,7 @@ impl TextInputTest {
                     border: green,
                     w: 40,
                     focusable,
+                    clear_on_submit,
                     @change: ctx.handler_with_value(Msg::SearchChanged),
                     @submit: ctx.handler(Msg::SearchSubmitted)
                 ),

--- a/rxtui/lib/components/text_input.rs
+++ b/rxtui/lib/components/text_input.rs
@@ -65,6 +65,9 @@ pub enum TextInputMsg {
 
     /// Submit (Enter key)
     Submit,
+
+    /// Clear the input content
+    Clear,
 }
 
 /// State for TextInput component
@@ -158,6 +161,7 @@ pub struct TextInput {
     focusable: bool,
     wrap: Option<TextWrap>,
     password_mode: bool,
+    clear_on_submit: bool,
     on_change: Option<Box<dyn Fn(String)>>,
     on_submit: Option<Box<dyn Fn()>>,
 }
@@ -376,6 +380,7 @@ impl TextInput {
             focusable: true,                 // Text inputs are focusable by default
             wrap: Some(TextWrap::WordBreak), // Default to WordBreak for better text wrapping
             password_mode: false,            // Default to normal text mode
+            clear_on_submit: false,          // Default to not clearing on submit
             on_change: None,
             on_submit: None,
         }
@@ -396,6 +401,12 @@ impl TextInput {
     /// Enables password mode which masks the input content
     pub fn password(mut self, password: bool) -> Self {
         self.password_mode = password;
+        self
+    }
+
+    /// Enables automatic clearing of input content on submit (Enter key)
+    pub fn clear_on_submit(mut self, clear: bool) -> Self {
+        self.clear_on_submit = clear;
         self
     }
 
@@ -600,6 +611,30 @@ impl TextInput {
                     // Call on_submit callback when Enter is pressed
                     if let Some(callback) = &self.on_submit {
                         callback();
+                    }
+
+                    // Clear content if clear_on_submit is enabled
+                    if self.clear_on_submit {
+                        state.content.clear();
+                        state.cursor_position = 0;
+                        state.selection_start = None;
+                        state.selection_end = None;
+
+                        // Call on_change callback to notify of cleared content
+                        if let Some(callback) = &self.on_change {
+                            callback(state.content.clone());
+                        }
+                    }
+                }
+                TextInputMsg::Clear => {
+                    state.content.clear();
+                    state.cursor_position = 0;
+                    state.selection_start = None;
+                    state.selection_end = None;
+
+                    // Call on_change callback
+                    if let Some(callback) = &self.on_change {
+                        callback(state.content.clone());
                     }
                 }
             }

--- a/rxtui/lib/macros/node.rs
+++ b/rxtui/lib/macros/node.rs
@@ -2082,6 +2082,24 @@ macro_rules! tui_apply_input_props {
         $input.password(true)
     }};
 
+    // Clear on submit with explicit value
+    ($input:expr, clear_on_submit: $value:expr, $($rest:tt)*) => {{
+        let i = $input.clear_on_submit($value);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, clear_on_submit: $value:expr) => {{
+        $input.clear_on_submit($value)
+    }};
+
+    // Clear on submit shorthand (enables clear on submit)
+    ($input:expr, clear_on_submit, $($rest:tt)*) => {{
+        let i = $input.clear_on_submit(true);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, clear_on_submit) => {{
+        $input.clear_on_submit(true)
+    }};
+
     // @change handler
     ($input:expr, @change: $handler:expr, $($rest:tt)*) => {{
         let i = $input.on_change($handler);


### PR DESCRIPTION
## Summary
This PR adds automatic input clearing functionality to the TextInput component:
- Implements `clear_on_submit` option that automatically clears input content when Enter is pressed
- Adds programmatic clearing via new `TextInputMsg::Clear` message variant
- Provides a common UX pattern for search boxes, chat inputs, and other forms where input should reset after submission
- Maintains backward compatibility as the feature is opt-in with default value `false`

## Changes
### TextInput Component (`rxtui/lib/components/text_input.rs`)
- Added `clear_on_submit: bool` field to TextInput struct (defaults to false)
- Added `clear_on_submit(bool)` builder method to enable the feature
- Added `TextInputMsg::Clear` message variant for programmatic clearing
- Modified `Submit` message handler to automatically clear when flag is enabled
- Clearing behavior: clears content, resets cursor to position 0, removes selection, and calls `on_change` callback

### Node Macro Support (`rxtui/lib/macros/node.rs`)
- Added macro rules for `clear_on_submit` property in `tui_apply_input_props!` macro
- Supports both explicit value (`clear_on_submit: true/false`) and shorthand (`clear_on_submit`)
- Follows same pattern as existing boolean properties like `password` and `focusable`

### Example Update (`examples/textinput.rs`)
- Updated search input example to demonstrate `clear_on_submit` feature
- Shows integration with search history tracking
- Demonstrates automatic state synchronization via `on_change` callback

## Test Plan
- Build the project: `cargo build --example textinput`
- Run the example: `cargo run --example textinput`
- Test the search input (field #3):
  - Type some text into the search field
  - Press Enter to submit
  - Verify the input field clears automatically
  - Verify the search term appears in the history list below
  - Verify the "Current" value updates correctly
- Test backward compatibility by verifying other inputs (fields #1 and #2) do not clear on submit