### PR TITLE
feat(app): support programmatic focus requests

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1010,6 +1010,30 @@ node! {
 - **Tab**: Move to next focusable element
 - **Shift+Tab**: Move to previous focusable element
 
+#### Programmatic Focus
+
+Use the `Context` focus helpers to move focus immediately after a render:
+
+```rust
+#[view]
+fn view(&self, ctx: &Context, state: MyState) -> Node {
+    if ctx.is_first_render() {
+        ctx.focus_self(); // focus the first focusable node in this component
+    }
+
+    node! {
+        div [
+            input(focusable),
+            button(focusable)
+        ]
+    }
+}
+```
+
+- `ctx.focus_self()` focuses the first focusable element inside the component's subtree.
+- `ctx.focus_first()` focuses the first focusable element in the entire app.
+- `ctx.is_first_render()` is handy for gating autofocus so you do not wrestle with user-driven focus changes later.
+
 <div align='center'>• • •</div>
 
 ## Built-in Components

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -194,6 +194,22 @@ div(
 ) []
 ```
 
+### Programmatic Focus
+
+```rust
+#[view]
+fn view(&self, ctx: &Context, state: MyState) -> Node {
+    if ctx.is_first_render() {
+        ctx.focus_self();      // focus first focusable inside this component
+        // ctx.focus_first();  // or focus the first focusable in the whole app
+    }
+
+    // Inside an event handler you can call ctx.blur_focus() to drop focus manually.
+
+    node! { div(focusable) [] }
+}
+```
+
 ### Optional Properties
 
 ```rust

--- a/examples/demo_pages/page12_focus.rs
+++ b/examples/demo_pages/page12_focus.rs
@@ -31,7 +31,6 @@ impl Page12FocusDemo {
                     text("• Shift+Tab: Navigate backward between focusable elements", color: bright_black),
                     text("• Click: Focus an element directly", color: bright_black),
                     text("• Enter: Activate focused button", color: bright_black),
-                    text("• Esc: Exit focus mode (clear focus)", color: bright_black),
                     text("• Focused elements have white borders", color: bright_black)
                 ],
                 spacer(2),

--- a/examples/form.rs
+++ b/examples/form.rs
@@ -48,7 +48,10 @@ impl Form {
                 align: center,
                 @key(esc): ctx.handler(Msg::Exit)
             ) [
-                text("tab to navigate | enter to submit | esc to exit", color: bright_black),
+                text(
+                    "tab to navigate | enter to submit | esc to exit",
+                    color: bright_black
+                ),
                 spacer(1),
 
                 // Form fields with callbacks

--- a/examples/textinput.rs
+++ b/examples/textinput.rs
@@ -12,6 +12,7 @@ enum Msg {
     PasswordSubmitted,
     SearchChanged(String),
     SearchSubmitted,
+    ExitFocus(bool),
     Exit,
 }
 
@@ -23,7 +24,7 @@ struct TextInputTestState {
     password_submit_count: usize,
     search_value: String,
     search_history: Vec<String>,
-    last_action: String,
+    exit_focused: bool,
 }
 
 #[derive(Component)]
@@ -39,28 +40,18 @@ impl TextInputTest {
         match msg {
             Msg::InputChanged(value) => {
                 state.input_value = value;
-                state.last_action = format!("Input changed to: '{}'", state.input_value);
             }
             Msg::InputSubmitted => {
                 state.input_submit_count += 1;
-                state.last_action =
-                    format!("Input submitted! (count: {})", state.input_submit_count);
             }
             Msg::PasswordChanged(value) => {
                 state.password_value = value;
-                state.last_action =
-                    format!("Password changed (length: {})", state.password_value.len());
             }
             Msg::PasswordSubmitted => {
                 state.password_submit_count += 1;
-                state.last_action = format!(
-                    "Password submitted! (count: {})",
-                    state.password_submit_count
-                );
             }
             Msg::SearchChanged(value) => {
                 state.search_value = value;
-                state.last_action = format!("Search changed to: '{}'", state.search_value);
             }
             Msg::SearchSubmitted => {
                 if !state.search_value.is_empty() {
@@ -68,12 +59,10 @@ impl TextInputTest {
                     if state.search_history.len() > 5 {
                         state.search_history.remove(0);
                     }
-                    state.last_action = format!("Search submitted: '{}'", state.search_value);
-                    // Note: input will be cleared automatically by clear_on_submit flag
-                    // The SearchChanged handler will receive empty string and update state.search_value
-                } else {
-                    state.last_action = "Search submitted but was empty".to_string();
                 }
+            }
+            Msg::ExitFocus(focused) => {
+                state.exit_focused = focused;
             }
             Msg::Exit => return Action::exit(),
         }
@@ -82,41 +71,28 @@ impl TextInputTest {
 
     #[view]
     fn view(&self, ctx: &Context, state: TextInputTestState) -> Node {
-        let action_color = if state.last_action.contains("submitted") {
-            Color::Green
+        if ctx.is_first_render() {
+            ctx.focus_self();
+        }
+
+        let exit_text_color = if state.exit_focused {
+            Color::Rgb(200, 32, 32)
         } else {
-            Color::Cyan
+            Color::BrightWhite
         };
-        // Build search history text
 
         node! {
             div(
                 bg: black,
                 pad: 2,
                 w_pct: 1.0,
-                h: 45,
+                h: 36,
                 dir: vertical,
                 @key(esc): ctx.handler(Msg::Exit)
             ) [
-                // Title
-                text("TextInput Component Test", color: bright_white, bold),
-                text("Press ESC to exit | Press ENTER in any field to submit", color: bright_black),
+                text("Press Enter to submit | Esc to exit", color: bright_black),
                 spacer(1),
 
-                // Last action indicator
-                text("Last Action:", color: yellow),
-                text(
-                    if state.last_action.is_empty() {
-                        "  No action yet".to_string()
-                    } else {
-                        format!("  {}", state.last_action)
-                    },
-                    color: action_color
-                ),
-                spacer(2),
-
-                // Basic input with submit counter
-                text("1. Basic Input (tracks Enter presses):", color: cyan),
                 input(
                     placeholder: "Type and press Enter...",
                     border: cyan,
@@ -126,16 +102,14 @@ impl TextInputTest {
                     @submit: ctx.handler(Msg::InputSubmitted)
                 ),
                 text(
-                    format!("  Value: '{}' | Submit count: {}",
+                    format!("Value: '{}' | Submits: {}",
                         state.input_value,
                         state.input_submit_count
                     ),
                     color: bright_black
                 ),
-                spacer(2),
+                spacer(1),
 
-                // Password input with submit
-                text("2. Password Input (masked, with submit):", color: magenta),
                 input(
                     placeholder: "Enter password and press Enter...",
                     password,
@@ -146,16 +120,14 @@ impl TextInputTest {
                     @submit: ctx.handler(Msg::PasswordSubmitted)
                 ),
                 text(
-                    format!("  Length: {} chars | Submit count: {}",
+                    format!("Password length: {} | Submits: {}",
                         state.password_value.len(),
                         state.password_submit_count
                     ),
                     color: bright_black
                 ),
-                spacer(2),
+                spacer(1),
 
-                // Search input that clears on submit
-                text("3. Search Input (clears on Enter, keeps history):", color: green),
                 input(
                     placeholder: "Search and press Enter...",
                     border: green,
@@ -166,41 +138,45 @@ impl TextInputTest {
                     @submit: ctx.handler(Msg::SearchSubmitted)
                 ),
                 text(
-                    format!("  Current: '{}'", state.search_value),
-                    color: bright_black
-                ),
-                spacer(1),
-
-                // Search history
-                text("Search History (last 5):", color: yellow),
-                text(
-                    state.search_history.iter().enumerate()
-                        .map(|(i, search)| format!("  {}. {}", i + 1, search))
-                        .collect::<Vec<_>>()
-                        .join("\n"),
+                    format!("Current search: '{}'", state.search_value),
                     color: bright_black
                 ),
                 text(
                     if state.search_history.is_empty() {
-                        "  No searches yet".to_string()
+                        "No searches yet".to_string()
                     } else {
-                        "".to_string()
+                        format!("Recent searches: {}",
+                            state.search_history
+                                .iter()
+                                .rev()
+                                .take(3)
+                                .cloned()
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
                     },
                     color: bright_black
                 ),
                 spacer(2),
 
-                // Instructions
-                text("Keyboard Shortcuts:", color: white, bold),
-                text("  • Enter: Submit the current field", color: green, bold),
-                text("  • Ctrl+W / Alt+Backspace: Delete word backward", color: bright_black),
-                text("  • Alt+D: Delete word forward", color: bright_black),
-                text("  • Ctrl+U: Delete to line start", color: bright_black),
-                text("  • Ctrl+K: Delete to line end", color: bright_black),
-                text("  • Ctrl+A / Home: Move to start", color: bright_black),
-                text("  • Ctrl+E / End: Move to end", color: bright_black),
-                text("  • Alt+B: Move word backward", color: bright_black),
-                text("  • Alt+F: Move word forward", color: bright_black)
+                div(
+                    border: (Color::Rgb(90, 0, 0)),
+                    border_style: rounded,
+                    focusable,
+                    focus_style: ({
+                        Style::default()
+                            .border(Color::Rgb(200, 40, 40))
+                            .background(Color::Rgb(60, 0, 0))
+                    }),
+                    w: 16,
+                    @click: ctx.handler(Msg::Exit),
+                    @key(enter): ctx.handler(Msg::Exit),
+                    @key(esc): ctx.handler(Msg::Exit),
+                    @focus: ctx.handler(Msg::ExitFocus(true)),
+                    @blur: ctx.handler(Msg::ExitFocus(false))
+                ) [
+                    text("Exit", color: (exit_text_color), bold)
+                ]
             ]
         }
     }

--- a/rxtui/lib/app/events.rs
+++ b/rxtui/lib/app/events.rs
@@ -11,8 +11,8 @@ use std::rc::Rc;
 
 /// Processes keyboard input events.
 ///
-/// Handles Tab/Shift+Tab for focus navigation, Escape to exit focus mode,
-/// Enter to activate focused elements, broadcasts to global handlers,
+/// Handles Tab/Shift+Tab for focus navigation, Enter to activate focused elements,
+/// broadcasts to global handlers,
 /// then routes other keys to the focused element.
 pub fn handle_key_event(vdom: &VDom, key_event: KeyEvent) {
     // Try to create both simple key and key with modifiers
@@ -27,18 +27,6 @@ pub fn handle_key_event(vdom: &VDom, key_event: KeyEvent) {
         if key == Key::BackTab {
             render_tree.focus_prev();
             return;
-        }
-
-        // Handle Escape to exit focus mode
-        if key == Key::Esc {
-            // Check if there's currently a focused node
-            if render_tree.get_focused_node().is_some() {
-                // Clear focus
-                render_tree.set_focused_node(None);
-                // Don't propagate the Escape key to other handlers
-                return;
-            }
-            // If nothing was focused, let Escape propagate normally
         }
 
         // Handle Enter to activate focused element

--- a/rxtui/lib/node/div.rs
+++ b/rxtui/lib/node/div.rs
@@ -1,3 +1,4 @@
+use crate::component::ComponentId;
 use crate::key::{Key, KeyWithModifiers};
 use crate::style::{
     AlignItems, AlignSelf, Border, BorderEdges, BorderStyle, Color, Dimension, Direction,
@@ -34,6 +35,9 @@ pub struct Div<T> {
 
     /// Whether this container is currently focused
     pub focused: bool,
+
+    /// Component path that owns this div (used for focus targeting)
+    pub component_path: Option<ComponentId>,
 }
 
 /// Style configuration for a div in different states.
@@ -89,6 +93,7 @@ impl<T> Div<T> {
             events: EventCallbacks::default(),
             focusable: false,
             focused: false,
+            component_path: None,
         }
     }
 
@@ -490,6 +495,7 @@ impl<T> Div<T> {
             events: self.events,
             focusable: self.focusable,
             focused: self.focused,
+            component_path: self.component_path,
         }
     }
 
@@ -519,6 +525,7 @@ impl<T: PartialEq> PartialEq for Div<T> {
             && self.styles == other.styles
             && self.focusable == other.focusable
             && self.focused == other.focused
+            && self.component_path == other.component_path
     }
 }
 

--- a/rxtui/lib/render_tree/node.rs
+++ b/rxtui/lib/render_tree/node.rs
@@ -1,4 +1,5 @@
 use crate::bounds::Rect;
+use crate::component::ComponentId;
 use crate::key::Key;
 use crate::node::{DivStyles, EventCallbacks, TextSpan};
 use crate::style::{
@@ -94,6 +95,9 @@ pub struct RenderNode {
 
     /// Whether this node is scrollable (has overflow:scroll or auto)
     pub scrollable: bool,
+
+    /// Component path that produced this node (used for focus targeting)
+    pub component_path: Option<ComponentId>,
 }
 
 /// Types of nodes that can be rendered.
@@ -188,6 +192,7 @@ impl RenderNode {
             content_width: 0,
             content_height: 0,
             scrollable: false,
+            component_path: None,
         }
     }
 

--- a/rxtui/lib/vdom.rs
+++ b/rxtui/lib/vdom.rs
@@ -216,6 +216,7 @@ impl VDom {
         render_node.events = div.events.clone();
         render_node.focusable = div.focusable;
         render_node.focused = div.focused;
+        render_node.component_path = div.component_path.clone();
 
         let node_rc = Rc::new(RefCell::new(render_node));
 
@@ -483,6 +484,7 @@ impl VDom {
                 node_ref.events = div.events.clone();
                 node_ref.focusable = div.focusable;
                 node_ref.focused = is_focused;
+                node_ref.component_path = div.component_path.clone();
                 node_ref.mark_dirty();
             }
             Patch::AddChild {


### PR DESCRIPTION
## Summary
- add Context focus helpers so components can queue focus/blur requests during render
- track first-render state on each component invocation to drive gating logic like autofocus
- propagate component ownership through divs/render nodes so the render tree can target component roots
- refresh focus documentation and demos, stopping the implicit Esc blur to respect user-driven focus

## Changes
- add focus request queue, first-render tracking, and public helpers in rxtui/lib/app/context.rs
- apply queued focus actions inside App render loop and tag vnode divs with their component path in rxtui/lib/app/core.rs
- allow render tree to locate component roots/first focusable nodes and carry component ids through div/render nodes (rxtui/lib/node/div.rs, rxtui/lib/render_tree/node.rs, rxtui/lib/render_tree/tree.rs, rxtui/lib/vdom.rs)
- remove automatic Esc blur and leave keyboard handling otherwise intact in rxtui/lib/app/events.rs
- update documentation and the form/textinput demos to showcase programmatic focus (DOCS.md, QUICK_REFERENCE.md, examples/...)

## Test Plan
- cargo check
- cargo fmt
- cargo clippy
