### PR TITLE
feat(lib): allow inputs to clear focus on esc

### DIFF
--- a/examples/form.rs
+++ b/examples/form.rs
@@ -5,6 +5,7 @@ enum Msg {
     UsernameChanged(String),
     PasswordChanged(String),
     Submit,
+    ClearFocus,
     Exit,
 }
 
@@ -20,7 +21,7 @@ struct Form;
 
 impl Form {
     #[update]
-    fn update(&self, _ctx: &Context, msg: Msg, mut state: FormState) -> Action {
+    fn update(&self, ctx: &Context, msg: Msg, mut state: FormState) -> Action {
         match msg {
             Msg::UsernameChanged(value) => {
                 state.username = value;
@@ -33,6 +34,7 @@ impl Form {
             Msg::Submit => {
                 state.submitted = !state.username.is_empty() && !state.password.is_empty();
             }
+            Msg::ClearFocus => ctx.blur_focus(),
             Msg::Exit => return Action::exit(),
         }
         Action::update(state)
@@ -63,7 +65,8 @@ impl Form {
                         focusable,
                         w: 40,
                         @change: ctx.handler_with_value(Msg::UsernameChanged),
-                        @submit: ctx.handler(Msg::Submit)
+                        @submit: ctx.handler(Msg::Submit),
+                        @key(esc): ctx.handler(Msg::ClearFocus)
                     )
                 ],
                 spacer(1),
@@ -77,7 +80,8 @@ impl Form {
                         focusable,
                         w: 40,
                         @change: ctx.handler_with_value(Msg::PasswordChanged),
-                        @submit: ctx.handler(Msg::Submit)
+                        @submit: ctx.handler(Msg::Submit),
+                        @key(esc): ctx.handler(Msg::ClearFocus)
                     )
                 ],
                 spacer(1),
@@ -93,7 +97,8 @@ impl Form {
                     border: white,
                     focusable,
                     focus_style: (Style::default().border(Color::hex("#ffffff"))),
-                    @click: ctx.handler(Msg::Submit)
+                    @click: ctx.handler(Msg::Submit),
+                    @key(esc): ctx.handler(Msg::ClearFocus)
                 ) [
                     hstack [
                         div(w_pct: 0.9, h: 1)[],

--- a/examples/textinput.rs
+++ b/examples/textinput.rs
@@ -13,6 +13,7 @@ enum Msg {
     SearchChanged(String),
     SearchSubmitted,
     ExitFocus(bool),
+    ClearFocus,
     Exit,
 }
 
@@ -36,7 +37,7 @@ struct TextInputTest;
 
 impl TextInputTest {
     #[update]
-    fn update(&self, _ctx: &Context, msg: Msg, mut state: TextInputTestState) -> Action {
+    fn update(&self, ctx: &Context, msg: Msg, mut state: TextInputTestState) -> Action {
         match msg {
             Msg::InputChanged(value) => {
                 state.input_value = value;
@@ -63,6 +64,9 @@ impl TextInputTest {
             }
             Msg::ExitFocus(focused) => {
                 state.exit_focused = focused;
+            }
+            Msg::ClearFocus => {
+                ctx.blur_focus();
             }
             Msg::Exit => return Action::exit(),
         }
@@ -99,7 +103,8 @@ impl TextInputTest {
                     w: 40,
                     focusable,
                     @change: ctx.handler_with_value(Msg::InputChanged),
-                    @submit: ctx.handler(Msg::InputSubmitted)
+                    @submit: ctx.handler(Msg::InputSubmitted),
+                    @key(esc): ctx.handler(Msg::ClearFocus)
                 ),
                 text(
                     format!("Value: '{}' | Submits: {}",
@@ -117,7 +122,8 @@ impl TextInputTest {
                     w: 40,
                     focusable,
                     @change: ctx.handler_with_value(Msg::PasswordChanged),
-                    @submit: ctx.handler(Msg::PasswordSubmitted)
+                    @submit: ctx.handler(Msg::PasswordSubmitted),
+                    @key(esc): ctx.handler(Msg::ClearFocus)
                 ),
                 text(
                     format!("Password length: {} | Submits: {}",
@@ -135,7 +141,8 @@ impl TextInputTest {
                     focusable,
                     clear_on_submit,
                     @change: ctx.handler_with_value(Msg::SearchChanged),
-                    @submit: ctx.handler(Msg::SearchSubmitted)
+                    @submit: ctx.handler(Msg::SearchSubmitted),
+                    @key(esc): ctx.handler(Msg::ClearFocus)
                 ),
                 text(
                     format!("Current search: '{}'", state.search_value),

--- a/rxtui/lib/macros/node.rs
+++ b/rxtui/lib/macros/node.rs
@@ -2117,4 +2117,31 @@ macro_rules! tui_apply_input_props {
     ($input:expr, @submit: $handler:expr) => {{
         $input.on_submit($handler)
     }};
+
+    // @key handler
+    ($input:expr, @key($key:tt): $handler:expr, $($rest:tt)*) => {{
+        let i = $input.on_key($crate::key_value!($key), $handler);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, @key($key:tt): $handler:expr) => {{
+        $input.on_key($crate::key_value!($key), $handler)
+    }};
+
+    // @key_global handler
+    ($input:expr, @key_global($key:tt): $handler:expr, $($rest:tt)*) => {{
+        let i = $input.on_key_global($crate::key_value!($key), $handler);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, @key_global($key:tt): $handler:expr) => {{
+        $input.on_key_global($crate::key_value!($key), $handler)
+    }};
+
+    // @blur handler
+    ($input:expr, @blur: $handler:expr, $($rest:tt)*) => {{
+        let i = $input.on_blur($handler);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, @blur: $handler:expr) => {{
+        $input.on_blur($handler)
+    }};
 }

--- a/rxtui/lib/vdom.rs
+++ b/rxtui/lib/vdom.rs
@@ -45,6 +45,7 @@ use crate::utils::display_width;
 use crate::vnode::VNode;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::{Arc, atomic::AtomicBool};
 
 //--------------------------------------------------------------------------------------------------
 // Types
@@ -122,6 +123,11 @@ impl VDom {
     /// Used by the App to access the tree for drawing and event handling.
     pub fn get_render_tree(&self) -> &RenderTree {
         &self.render_tree
+    }
+
+    /// Returns the shared focus-clear flag for coordination with contexts.
+    pub fn focus_clear_flag(&self) -> Arc<AtomicBool> {
+        self.render_tree.focus_clear_flag()
     }
 
     /// Creates a render node from a node.


### PR DESCRIPTION
## Summary
- Add a shared focus-clear flag and `Context::blur_focus` so components can drop focus intentionally within a frame
- Motivation: allow users to press Esc to leave a field without exiting the app, requiring explicit blur support
- Expected impact: App respects pending clears while cancelling them when a new focus target wins, yielding consistent Esc behavior
- Context: extend `TextInput`/macros and update the form & textinput demos to showcase `@key(esc)` and `@blur`

## Changes
- rxtui/lib/app/context.rs: store an `Arc<AtomicBool>` pending focus-clear flag and expose blur/clear helpers shared across child contexts
- rxtui/lib/app/core.rs: construct `Context` with the VDom flag and apply pending focus clears after processing focus requests
- rxtui/lib/render_tree/tree.rs: hold the shared flag, skip redundant focus updates, and reset pending clears whenever focus moves
- rxtui/lib/vdom.rs: expose `focus_clear_flag` so the App can coordinate focus clearing with contexts
- rxtui/lib/components/text_input.rs: add `on_blur`, `on_key`, and `on_key_global` hooks, invoking blur callbacks and key handlers during render
- rxtui/lib/macros/node.rs: map new `@key(...)`, `@key_global(...)`, and `@blur` directives to the corresponding TextInput builders
- examples/form.rs & examples/textinput.rs: wire `@key(esc)` to `ctx.blur_focus()` so demos illustrate clearing focus with Esc

## Test Plan
- `cargo check`
- `cargo run --example form` (Esc while an input is focused clears focus; Esc on the outer container still exits)
- `cargo run --example textinput` (Esc blurs whichever input is focused and leaves the app running)
