### PR TITLE
feat(lib): add hover styling state management

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -67,6 +67,20 @@ CSS Flexbox-style alignment demonstration:
 
 <br />
 
+### [hover.rs](./hover.rs)
+```bash
+cargo run --example hover
+```
+
+Demonstrates pointer-driven styling:
+- Cards highlight with `hover_style` overlays and animated borders
+- Keyboard tabbing still works via `focus_style` fallbacks
+- Shows how to compose base, focus, and hover layers without extra event wiring
+- Includes a `TextInput` with hover/focus styling via `hover_*` helpers
+- Great starting point for interactive menus and dashboards
+
+<br />
+
 ### [progressbar.rs](./progressbar.rs)
 ```bash
 cargo run --example progressbar

--- a/examples/hover.rs
+++ b/examples/hover.rs
@@ -1,0 +1,102 @@
+use rxtui::prelude::*;
+
+const ITEMS: &[(&str, &str)] = &[
+    ("Inbox", "5 unread conversations waiting"),
+    ("Team Standup", "Next session today at 10:00"),
+    ("Deploy Preview", "Version 1.8.2 awaiting approval"),
+    ("Release Notes", "Draft ready for review"),
+];
+
+const ACCENTS: [Color; 4] = [Color::Cyan, Color::Magenta, Color::Yellow, Color::Green];
+
+#[derive(Component)]
+struct HoverShowcase;
+
+impl HoverShowcase {
+    #[update]
+    fn update(&self, _ctx: &Context, msg: &str) -> Action {
+        if matches!(msg, "exit") {
+            Action::exit()
+        } else {
+            Action::none()
+        }
+    }
+
+    #[view]
+    fn view(&self, ctx: &Context) -> Node {
+        node! {
+            div(
+                dir: vertical,
+                pad: 2,
+                gap: 2,
+                bg: (Color::Rgb(12, 13, 24)),
+                w_pct: 1.0,
+                h_pct: 1.0,
+                @key_global(esc): ctx.handler("exit"),
+            ) [
+                text("Interactive Hover Cards", color: cyan, bold),
+                text("Move your mouse across the cards to see hover styling.", color: bright_black),
+                div(dir: vertical, gap: 1) [
+                    ...(ITEMS.iter().enumerate().map(|(index, (title, subtitle))| {
+                        let accent = ACCENTS[index % ACCENTS.len()];
+                        node! {
+                            div(
+                                dir: vertical,
+                                gap: 0,
+                                pad: 1,
+                                bg: (Color::Rgb(24, 26, 36)),
+                                border_style: (BorderStyle::Rounded, Color::Rgb(34, 37, 49)),
+                                focusable,
+                                focus_style: (
+                                    Style {
+                                        border: Some(Border::with_style(BorderStyle::Rounded, Color::BrightBlue)),
+                                        ..Style::default()
+                                    }
+                                ),
+                                hover_style: (
+                                    Style {
+                                        background: Some(Color::Rgb(36, 40, 56)),
+                                        border: Some(Border::with_style(BorderStyle::Rounded, accent)),
+                                        ..Style::default()
+                                    }
+                                )
+                            ) [
+                                text(*title, color: white, bold),
+                                text(*subtitle, color: bright_black)
+                            ]
+                        }
+                    }).collect::<Vec<_>>())
+                ],
+                spacer(1),
+                div(dir: vertical, gap: 1) [
+                    text("Try the hover-enabled search box:", color: bright_black),
+                    input(
+                        placeholder: "Hover or focus me...",
+                        w: 46,
+                        bg: (Color::Rgb(20, 22, 32)),
+                        border_style: (BorderStyle::Rounded, Color::Rgb(34, 37, 49)),
+                        focus_style: (
+                            Style {
+                                border: Some(Border::with_style(BorderStyle::Rounded, Color::BrightBlue)),
+                                padding: Some(Spacing::horizontal(1)),
+                                ..Style::default()
+                            }
+                        ),
+                        hover_style: (
+                            Style {
+                                background: Some(Color::Rgb(36, 40, 56)),
+                                border: Some(Border::with_style(BorderStyle::Rounded, Color::Cyan)),
+                                padding: Some(Spacing::horizontal(1)),
+                                ..Style::default()
+                            }
+                        )
+                    )
+                ]
+            ]
+        }
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    App::new()?.run(HoverShowcase)
+}

--- a/rxtui/lib/app/core.rs
+++ b/rxtui/lib/app/core.rs
@@ -539,6 +539,7 @@ impl App {
                 vnode_div.events = div.events;
                 vnode_div.focusable = div.focusable;
                 vnode_div.focused = div.focused;
+                vnode_div.hovered = div.hovered;
                 vnode_div.component_path = Some(parent_id);
 
                 Ok(VNode::Div(vnode_div))

--- a/rxtui/lib/app/events.rs
+++ b/rxtui/lib/app/events.rs
@@ -175,6 +175,7 @@ pub fn handle_mouse_event(vdom: &VDom, mouse_event: MouseEvent) {
     match mouse_event.kind {
         MouseEventKind::Down(_) => {
             if let Some(node) = render_tree.find_node_at(mouse_event.column, mouse_event.row) {
+                render_tree.set_hovered_node(Some(node.clone()));
                 // Set focus if the node is focusable
                 {
                     let node_ref = node.borrow();
@@ -186,11 +187,14 @@ pub fn handle_mouse_event(vdom: &VDom, mouse_event: MouseEvent) {
 
                 // Handle the click
                 node.borrow().handle_click();
+            } else {
+                render_tree.set_hovered_node(None);
             }
         }
         MouseEventKind::ScrollUp => {
             // Find the scrollable node at the mouse position
             if let Some(node) = render_tree.find_node_at(mouse_event.column, mouse_event.row) {
+                render_tree.set_hovered_node(Some(node.clone()));
                 // Find the nearest scrollable ancestor (including self)
                 if let Some(scrollable_node) = find_scrollable_ancestor(&node) {
                     let mut node_ref = scrollable_node.borrow_mut();
@@ -199,11 +203,14 @@ pub fn handle_mouse_event(vdom: &VDom, mouse_event: MouseEvent) {
                         node_ref.mark_dirty();
                     }
                 }
+            } else {
+                render_tree.set_hovered_node(None);
             }
         }
         MouseEventKind::ScrollDown => {
             // Find the scrollable node at the mouse position
             if let Some(node) = render_tree.find_node_at(mouse_event.column, mouse_event.row) {
+                render_tree.set_hovered_node(Some(node.clone()));
                 // Find the nearest scrollable ancestor (including self)
                 if let Some(scrollable_node) = find_scrollable_ancestor(&node) {
                     let mut node_ref = scrollable_node.borrow_mut();
@@ -212,7 +219,17 @@ pub fn handle_mouse_event(vdom: &VDom, mouse_event: MouseEvent) {
                         node_ref.mark_dirty();
                     }
                 }
+            } else {
+                render_tree.set_hovered_node(None);
             }
+        }
+        MouseEventKind::Moved | MouseEventKind::Drag(_) => {
+            let hovered = render_tree.find_node_at(mouse_event.column, mouse_event.row);
+            render_tree.set_hovered_node(hovered);
+        }
+        MouseEventKind::Up(_) => {
+            let hovered = render_tree.find_node_at(mouse_event.column, mouse_event.row);
+            render_tree.set_hovered_node(hovered);
         }
         _ => {}
     }

--- a/rxtui/lib/components/text_input.rs
+++ b/rxtui/lib/components/text_input.rs
@@ -690,6 +690,11 @@ impl TextInput {
             container = container.focus_style(focus.clone());
         }
 
+        // Apply hover style if we have one
+        if let Some(hover) = &self.styles.hover {
+            container = container.hover_style(hover.clone());
+        }
+
         // Set focusable
         if self.focusable {
             container = container.focusable(true);
@@ -1018,6 +1023,12 @@ impl TextInput {
         self
     }
 
+    /// Sets the hover style
+    pub fn hover_style(mut self, style: Style) -> Self {
+        self.styles.hover = Some(style);
+        self
+    }
+
     /// Sets the border color when focused
     pub fn focus_border(mut self, color: Color) -> Self {
         let mut style = self.styles.focus.clone().unwrap_or_default();
@@ -1058,6 +1069,49 @@ impl TextInput {
         let mut style = self.styles.focus.clone().unwrap_or_default();
         style.padding = Some(padding);
         self.styles.focus = Some(style);
+        self
+    }
+
+    /// Sets the border color when hovered
+    pub fn hover_border(mut self, color: Color) -> Self {
+        let mut style = self.styles.hover.clone().unwrap_or_default();
+        if style.border.is_none() {
+            style.border = Some(Border::new(color));
+        }
+        if let Some(ref mut border) = style.border {
+            border.color = color;
+            border.enabled = true;
+        }
+        self.styles.hover = Some(style);
+        self
+    }
+
+    /// Sets the border style and color when hovered
+    pub fn hover_border_style(mut self, border_style: BorderStyle, color: Color) -> Self {
+        let mut style = self.styles.hover.clone().unwrap_or_default();
+        style.border = Some(Border {
+            enabled: true,
+            style: border_style,
+            color,
+            edges: BorderEdges::ALL,
+        });
+        self.styles.hover = Some(style);
+        self
+    }
+
+    /// Sets the background color when hovered
+    pub fn hover_background(mut self, color: Color) -> Self {
+        let mut style = self.styles.hover.clone().unwrap_or_default();
+        style.background = Some(color);
+        self.styles.hover = Some(style);
+        self
+    }
+
+    /// Sets the padding when hovered
+    pub fn hover_padding(mut self, padding: Spacing) -> Self {
+        let mut style = self.styles.hover.clone().unwrap_or_default();
+        style.padding = Some(padding);
+        self.styles.hover = Some(style);
         self
     }
 

--- a/rxtui/lib/diff.rs
+++ b/rxtui/lib/diff.rs
@@ -180,18 +180,20 @@ fn diff_div(
 ) {
     let props_changed = {
         let old_style = &old_ref.style;
-        // Use the OLD node's focus state, not the new div's (which is always false)
+        // Use the OLD node's state flags, not the new div's (which default to false)
         let is_focused = old_ref.focused;
-        // Get effective style based on the preserved focus state
-        let new_style = if is_focused {
-            crate::style::Style::merge(new_div.styles.base.clone(), new_div.styles.focus.clone())
-        } else {
-            new_div.styles.base.clone()
-        };
-        let new_style = &new_style;
+        let is_hovered = old_ref.hovered;
+        // Get effective style based on the preserved focus/hover state
+        let new_style = RenderNode::compose_state_style(
+            &new_div.styles,
+            new_div.focusable,
+            is_focused,
+            is_hovered,
+        );
+        let new_style_ref = &new_style;
 
         // Check if dimensions changed (including percentage values)
-        let dimensions_changed = match (old_style, new_style) {
+        let dimensions_changed = match (old_style, new_style_ref) {
             (Some(old_s), Some(new_s)) => {
                 old_s.width != new_s.width || old_s.height != new_s.height
             }
@@ -199,7 +201,7 @@ fn diff_div(
             (None, None) => false,
         };
 
-        old_style != new_style || dimensions_changed
+        old_style != new_style_ref || dimensions_changed
     };
 
     if props_changed {

--- a/rxtui/lib/macros/node.rs
+++ b/rxtui/lib/macros/node.rs
@@ -1294,6 +1294,32 @@ macro_rules! tui_apply_props {
         }
     }};
 
+    // Hover style
+    ($container:expr, hover_style: ($style:expr), $($rest:tt)*) => {{
+        let c = $container.hover_style($style);
+        $crate::tui_apply_props!(c, $($rest)*)
+    }};
+    ($container:expr, hover_style: ($style:expr)) => {{
+        $container.hover_style($style)
+    }};
+
+    // Hover style - optional with ! suffix on expression
+    ($container:expr, hover_style: ($style:expr)!, $($rest:tt)*) => {{
+        let c = if let Some(style_val) = $style {
+            $container.hover_style(style_val)
+        } else {
+            $container
+        };
+        $crate::tui_apply_props!(c, $($rest)*)
+    }};
+    ($container:expr, hover_style: ($style:expr)!) => {{
+        if let Some(style_val) = $style {
+            $container.hover_style(style_val)
+        } else {
+            $container
+        }
+    }};
+
     // Z-index
     ($container:expr, z: $index:expr, $($rest:tt)*) => {{
         let c = $container.z_index($index);
@@ -1929,6 +1955,181 @@ macro_rules! tui_apply_input_props {
         $input.height($value)
     }};
 
+    // Focus style
+    ($input:expr, focus_style: ($style:expr), $($rest:tt)*) => {{
+        let i = $input.focus_style($style);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_style: ($style:expr)) => {{
+        $input.focus_style($style)
+    }};
+
+    // Focus style optional expression
+    ($input:expr, focus_style: ($style:expr)!, $($rest:tt)*) => {{
+        let i = if let Some(style_val) = $style {
+            $input.focus_style(style_val)
+        } else {
+            $input
+        };
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_style: ($style:expr)!) => {{
+        if let Some(style_val) = $style {
+            $input.focus_style(style_val)
+        } else {
+            $input
+        }
+    }};
+
+    // Focus border color
+    ($input:expr, focus_border: $color:tt, $($rest:tt)*) => {{
+        let i = $input.focus_border($crate::color_value!($color));
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_border: $color:tt) => {{
+        $input.focus_border($crate::color_value!($color))
+    }};
+    ($input:expr, focus_border: ($color:expr), $($rest:tt)*) => {{
+        let i = $input.focus_border($color);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_border: ($color:expr)) => {{
+        $input.focus_border($color)
+    }};
+
+    // Focus border style with color
+    ($input:expr, focus_border_style: ($style:expr, $color:expr), $($rest:tt)*) => {{
+        let i = $input.focus_border_style($style, $color);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_border_style: ($style:expr, $color:expr)) => {{
+        $input.focus_border_style($style, $color)
+    }};
+
+    // Focus background
+    ($input:expr, focus_background: $color:tt, $($rest:tt)*) => {{
+        let i = $input.focus_background($crate::color_value!($color));
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_background: $color:tt) => {{
+        $input.focus_background($crate::color_value!($color))
+    }};
+    ($input:expr, focus_background: ($color:expr), $($rest:tt)*) => {{
+        let i = $input.focus_background($color);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_background: ($color:expr)) => {{
+        $input.focus_background($color)
+    }};
+
+    // Focus padding using scalar value
+    ($input:expr, focus_padding: $value:expr, $($rest:tt)*) => {{
+        let i = $input.focus_padding($crate::Spacing::all($value));
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_padding: $value:expr) => {{
+        $input.focus_padding($crate::Spacing::all($value))
+    }};
+    ($input:expr, focus_padding: ($spacing:expr), $($rest:tt)*) => {{
+        let i = $input.focus_padding($spacing);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, focus_padding: ($spacing:expr)) => {{
+        $input.focus_padding($spacing)
+    }};
+
+    // Hover style
+    ($input:expr, hover_style: ($style:expr), $($rest:tt)*) => {{
+        let i = $input.hover_style($style);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_style: ($style:expr)) => {{
+        $input.hover_style($style)
+    }};
+
+    // Hover style optional expression
+    ($input:expr, hover_style: ($style:expr)!, $($rest:tt)*) => {{
+        let i = if let Some(style_val) = $style {
+            $input.hover_style(style_val)
+        } else {
+            $input
+        };
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_style: ($style:expr)!) => {{
+        if let Some(style_val) = $style {
+            $input.hover_style(style_val)
+        } else {
+            $input
+        }
+    }};
+
+    // Hover border color
+    ($input:expr, hover_border: $color:tt, $($rest:tt)*) => {{
+        let i = $input.hover_border($crate::color_value!($color));
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_border: $color:tt) => {{
+        $input.hover_border($crate::color_value!($color))
+    }};
+    ($input:expr, hover_border: ($color:expr), $($rest:tt)*) => {{
+        let i = $input.hover_border($color);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_border: ($color:expr)) => {{
+        $input.hover_border($color)
+    }};
+
+    // Hover background
+    ($input:expr, hover_background: $color:tt, $($rest:tt)*) => {{
+        let i = $input.hover_background($crate::color_value!($color));
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_background: $color:tt) => {{
+        $input.hover_background($crate::color_value!($color))
+    }};
+    ($input:expr, hover_background: ($color:expr), $($rest:tt)*) => {{
+        let i = $input.hover_background($color);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_background: ($color:expr)) => {{
+        $input.hover_background($color)
+    }};
+
+    // Hover padding using scalar value
+    ($input:expr, hover_padding: $value:expr, $($rest:tt)*) => {{
+        let i = $input.hover_padding($crate::Spacing::all($value));
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_padding: $value:expr) => {{
+        $input.hover_padding($crate::Spacing::all($value))
+    }};
+
+    // Hover padding with explicit spacing expression
+    ($input:expr, hover_padding: ($spacing:expr), $($rest:tt)*) => {{
+        let i = $input.hover_padding($spacing);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_padding: ($spacing:expr)) => {{
+        $input.hover_padding($spacing)
+    }};
+
+    // Hover padding shorthand alias
+    ($input:expr, hover_pad: $value:expr, $($rest:tt)*) => {{
+        let i = $input.hover_padding($crate::Spacing::all($value));
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_pad: $value:expr) => {{
+        $input.hover_padding($crate::Spacing::all($value))
+    }};
+    ($input:expr, hover_pad: ($spacing:expr), $($rest:tt)*) => {{
+        let i = $input.hover_padding($spacing);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, hover_pad: ($spacing:expr)) => {{
+        $input.hover_padding($spacing)
+    }};
+
     // Border color (now using the more explicit name)
     ($input:expr, border_color: $color:tt, $($rest:tt)*) => {{
         let i = $input.border($crate::color_value!($color));
@@ -1945,6 +2146,15 @@ macro_rules! tui_apply_input_props {
     }};
     ($input:expr, border_color: ($color:expr)) => {{
         $input.border($color)
+    }};
+
+    // Border style with color
+    ($input:expr, border_style: ($style:expr, $color:expr), $($rest:tt)*) => {{
+        let i = $input.border_style($style, $color);
+        $crate::tui_apply_input_props!(i, $($rest)*)
+    }};
+    ($input:expr, border_style: ($style:expr, $color:expr)) => {{
+        $input.border_style($style, $color)
     }};
 
     // Legacy border support (maps to border_color)

--- a/rxtui/lib/node/div.rs
+++ b/rxtui/lib/node/div.rs
@@ -36,6 +36,9 @@ pub struct Div<T> {
     /// Whether this container is currently focused
     pub focused: bool,
 
+    /// Whether this container is currently hovered
+    pub hovered: bool,
+
     /// Component path that owns this div (used for focus targeting)
     pub component_path: Option<ComponentId>,
 }
@@ -49,7 +52,7 @@ pub struct DivStyles {
     /// Style to apply when div is focused
     pub focus: Option<Style>,
 
-    /// Style to apply when div is hovered (future feature)
+    /// Style to apply when div is hovered
     pub hover: Option<Style>,
 }
 
@@ -93,6 +96,7 @@ impl<T> Div<T> {
             events: EventCallbacks::default(),
             focusable: false,
             focused: false,
+            hovered: false,
             component_path: None,
         }
     }
@@ -396,6 +400,12 @@ impl<T> Div<T> {
         self
     }
 
+    /// Sets the hover style
+    pub fn hover_style(mut self, style: Style) -> Self {
+        self.styles.hover = Some(style);
+        self
+    }
+
     /// Sets the base style directly
     pub fn style(mut self, style: Style) -> Self {
         self.styles.base = Some(style);
@@ -495,6 +505,7 @@ impl<T> Div<T> {
             events: self.events,
             focusable: self.focusable,
             focused: self.focused,
+            hovered: self.hovered,
             component_path: self.component_path,
         }
     }
@@ -503,6 +514,8 @@ impl<T> Div<T> {
     pub fn active_style(&self) -> Option<&Style> {
         if self.focused && self.styles.focus.is_some() {
             self.styles.focus.as_ref()
+        } else if self.hovered && self.styles.hover.is_some() {
+            self.styles.hover.as_ref()
         } else {
             self.styles.base.as_ref()
         }
@@ -525,6 +538,7 @@ impl<T: PartialEq> PartialEq for Div<T> {
             && self.styles == other.styles
             && self.focusable == other.focusable
             && self.focused == other.focused
+            && self.hovered == other.hovered
             && self.component_path == other.component_path
     }
 }
@@ -570,6 +584,7 @@ impl<T: Debug> Debug for Div<T> {
             .field("events", &self.events)
             .field("focusable", &self.focusable)
             .field("focused", &self.focused)
+            .field("hovered", &self.hovered)
             .finish()
     }
 }

--- a/rxtui/lib/vdom.rs
+++ b/rxtui/lib/vdom.rs
@@ -153,76 +153,14 @@ impl VDom {
         // Create a standard element render node
         let mut render_node = RenderNode::element();
 
-        // Apply the correct style based on focus state
-        let effective_style = if div.focused {
-            // For focused elements, merge: base -> default focus -> custom focus
-            let default_focus = if div.focusable {
-                Some(crate::style::Style::default_focus())
-            } else {
-                None
-            };
-
-            let focus_with_defaults =
-                crate::style::Style::merge(default_focus, div.styles.focus.clone());
-            crate::style::Style::merge(div.styles.base.clone(), focus_with_defaults)
-        } else {
-            div.styles.base.clone()
-        };
-
-        if let Some(style) = effective_style {
-            // Extract dimensions from style before moving it
-            match style.width {
-                Some(crate::style::Dimension::Fixed(width)) => {
-                    render_node.width = width;
-                }
-                Some(crate::style::Dimension::Percentage(_)) => {
-                    // Percentage will be resolved during layout
-                    // Keep width as 0 to indicate it needs resolution
-                }
-                Some(crate::style::Dimension::Auto) => {
-                    // Auto will be resolved during layout
-                    // Keep width as 0 to indicate it needs resolution
-                }
-                Some(crate::style::Dimension::Content) => {
-                    // Content will be resolved during layout
-                    // Keep width as 0 to indicate it needs resolution
-                }
-                None => {}
-            }
-
-            match style.height {
-                Some(crate::style::Dimension::Fixed(height)) => {
-                    render_node.height = height;
-                }
-                Some(crate::style::Dimension::Percentage(_)) => {
-                    // Percentage will be resolved during layout
-                    // Keep height as 0 to indicate it needs resolution
-                }
-                Some(crate::style::Dimension::Auto) => {
-                    // Auto will be resolved during layout
-                    // Keep height as 0 to indicate it needs resolution
-                }
-                Some(crate::style::Dimension::Content) => {
-                    // Content will be resolved during layout
-                    // Keep height as 0 to indicate it needs resolution
-                }
-                None => {}
-            }
-
-            // Extract positioning and z-index
-            render_node.position_type = style.position.unwrap_or(crate::style::Position::Relative);
-            render_node.z_index = style.z_index.unwrap_or(0);
-
-            // Now assign the style after we're done extracting values from it
-            render_node.style = Some(style);
-        }
-
         // Copy div properties to render node
         render_node.styles = div.styles.clone();
         render_node.events = div.events.clone();
         render_node.focusable = div.focusable;
         render_node.focused = div.focused;
+        render_node.hovered = div.hovered;
         render_node.component_path = div.component_path.clone();
+        render_node.refresh_state_style();
 
         let node_rc = Rc::new(RefCell::new(render_node));
 
@@ -424,73 +362,16 @@ impl VDom {
 
                 // Preserve the existing focus state from the old node
                 let is_focused = node_ref.focused;
-
-                // Apply the correct style based on the preserved focus state
-                let effective_style = if is_focused {
-                    // For focused elements, merge: base -> default focus -> custom focus
-                    let default_focus = if div.focusable {
-                        Some(crate::style::Style::default_focus())
-                    } else {
-                        None
-                    };
-
-                    let focus_with_defaults =
-                        crate::style::Style::merge(default_focus, div.styles.focus.clone());
-                    crate::style::Style::merge(div.styles.base.clone(), focus_with_defaults)
-                } else {
-                    div.styles.base.clone()
-                };
-
-                if let Some(style) = effective_style {
-                    // Extract dimensions from style before assigning
-                    match style.width {
-                        Some(crate::style::Dimension::Fixed(width)) => {
-                            node_ref.width = width;
-                        }
-                        Some(crate::style::Dimension::Percentage(_)) => {
-                            // Percentage will be resolved during layout
-                            // Keep width as 0 to indicate it needs resolution
-                        }
-                        Some(crate::style::Dimension::Auto) => {
-                            // Auto will be resolved during layout
-                            // Keep width as 0 to indicate it needs resolution
-                        }
-                        Some(crate::style::Dimension::Content) => {
-                            // Content will be resolved during layout
-                            // Keep width as 0 to indicate it needs resolution
-                        }
-                        None => {}
-                    }
-
-                    match style.height {
-                        Some(crate::style::Dimension::Fixed(height)) => {
-                            node_ref.height = height;
-                        }
-                        Some(crate::style::Dimension::Percentage(_)) => {
-                            // Percentage will be resolved during layout
-                            // Keep height as 0 to indicate it needs resolution
-                        }
-                        Some(crate::style::Dimension::Auto) => {
-                            // Auto will be resolved during layout
-                            // Keep height as 0 to indicate it needs resolution
-                        }
-                        Some(crate::style::Dimension::Content) => {
-                            // Content will be resolved during layout
-                            // Keep height as 0 to indicate it needs resolution
-                        }
-                        None => {}
-                    }
-
-                    // Now assign the style
-                    node_ref.style = Some(style);
-                }
+                let is_hovered = node_ref.hovered;
 
                 // Update container properties but preserve focus state
                 node_ref.styles = div.styles.clone();
                 node_ref.events = div.events.clone();
                 node_ref.focusable = div.focusable;
                 node_ref.focused = is_focused;
+                node_ref.hovered = is_hovered;
                 node_ref.component_path = div.component_path.clone();
+                node_ref.refresh_state_style();
                 node_ref.mark_dirty();
             }
             Patch::AddChild {


### PR DESCRIPTION
## Summary
- Add pointer-driven hover tracking so render nodes recompute styles when the cursor moves
- Layer base, focus, and hover styles through a single composition routine for predictable visuals
- Expose hover helpers in the node/input DSL and showcase them with a new hover example and docs update
- Enables richer interactive cards and inputs without manual event plumbing

## Changes
- Update render graph (`rxtui/lib/render_tree/node.rs`, `tree.rs`, `vdom.rs`, `diff.rs`, `app/events.rs`, `app/core.rs`, `node/div.rs`) to persist hovered state and refresh styles from pointer events
- Extend input styling APIs (`rxtui/lib/components/text_input.rs`) and macro arms (`rxtui/lib/macros/node.rs`) with hover builders and shorthands
- Document functionality through a new `examples/hover.rs` demo and README entry for quick discovery

## Test Plan
- cargo check
- cargo fmt
- cargo clippy
