### PR TITLE
chore(release): bump version to 0.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rxtui-workspace"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 publish = false
 
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 authors = ["Microsandbox Team"]
 license = "Apache-2.0"

--- a/rxtui/Cargo.toml
+++ b/rxtui/Cargo.toml
@@ -20,7 +20,7 @@ default = ["effects"]
 effects = ["tokio", "futures"]
 
 [dependencies]
-rxtui-macros = { version = "0.1.5", path = "../rxtui-macros" }
+rxtui-macros = { version = "0.1.6", path = "../rxtui-macros" }
 bitflags = "2.4"
 crossterm = "0.28"
 serde.workspace = true


### PR DESCRIPTION
## Summary
This release bumps the package version from 0.1.5 to 0.1.6, consolidating several feature additions and improvements made since the last release:

- Introduces comprehensive text input enhancements with flexible layout modes
- Adds hover state management system for interactive components
- Improves focus management with programmatic control and ESC key handling
- Enhances component APIs with workflow-focused options
- Refactors internal codebase for better maintainability

The release includes 1,724 line insertions and 462 deletions across 24 files, representing significant improvements to the library's component system and developer experience.

## Changes

### Version Updates
- Updated workspace version in root Cargo.toml from 0.1.5 to 0.1.6
- Updated workspace.package.version from 0.1.5 to 0.1.6
- Updated rxtui-macros dependency version in rxtui/Cargo.toml from 0.1.5 to 0.1.6

### Changelog (0.1.5 -> 0.1.6)

**Features:**
- Extended TextInput with inline/block layout modes and advanced key modifiers
  (Ctrl+A for select all, Ctrl+U for clear line)
- Added comprehensive hover state management system with proper state tracking
  for interactive components
- Implemented ESC key handling to clear focus from input components
- Added programmatic focus request API (App::request_focus) for better focus
  control in complex UIs
- Enhanced TextInput with clear_on_submit option for form submission workflows

**Refactoring:**
- Removed dead code and made internal modules private (#34)
- Improved API surface by hiding implementation details

**Files Modified:**
- Cargo.toml: workspace and package version bumps
- rxtui/Cargo.toml: internal dependency version update

## Test Plan
- Run `cargo check --all` to verify successful compilation with new version
- Run `cargo test --all` to ensure all 113 unit tests pass
- Run `cargo clippy --all` to verify no lint warnings
- Run `cargo build --all` to confirm successful build
- Verify version numbers are consistent across workspace:
  - Check workspace.package.version in root Cargo.toml shows 0.1.6
  - Check rxtui-macros dependency version in rxtui/Cargo.toml shows 0.1.6
- Note: Publishing requires rxtui-macros v0.1.6 to be published to crates.io
  before rxtui can be published