### PR TITLE
feat(app): add inline rendering mode for CLI tools

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -538,9 +538,83 @@ pub struct App {
 }
 
 impl App {
+    /// Creates app with alternate screen mode (default).
     pub fn new() -> Result<Self>;
-    pub fn with_config(config: RenderConfig) -> Result<Self>;
+
+    /// Creates app with inline rendering mode.
+    /// Content renders directly in terminal and persists after exit.
+    pub fn inline() -> Result<Self>;
+
+    /// Creates app with custom inline configuration.
+    pub fn inline_with_config(config: InlineConfig) -> Result<Self>;
+
+    /// Creates app with specified terminal mode.
+    pub fn with_mode(mode: TerminalMode) -> Result<Self>;
+
+    /// Runs the application with the given root component.
     pub fn run<C: Component>(&mut self, root: C) -> Result<()>;
+}
+```
+
+### TerminalMode
+
+```rust
+/// Terminal rendering mode.
+pub enum TerminalMode {
+    /// Full-screen alternate buffer (default behavior).
+    /// Content disappears when app exits.
+    AlternateScreen,
+
+    /// Inline rendering in main terminal buffer.
+    /// Content persists in terminal history after app exits.
+    Inline(InlineConfig),
+}
+```
+
+### InlineConfig
+
+```rust
+/// Configuration for inline rendering mode.
+pub struct InlineConfig {
+    /// How to determine rendering height.
+    pub height: InlineHeight,
+
+    /// Whether to show cursor during rendering.
+    pub cursor_visible: bool,
+
+    /// Whether to preserve output after app exits.
+    pub preserve_on_exit: bool,
+
+    /// Whether to capture mouse events.
+    /// Default is false to allow natural terminal scrolling.
+    pub mouse_capture: bool,
+}
+
+impl Default for InlineConfig {
+    fn default() -> Self {
+        Self {
+            height: InlineHeight::Content { max: None },
+            cursor_visible: false,
+            preserve_on_exit: true,
+            mouse_capture: false,
+        }
+    }
+}
+```
+
+### InlineHeight
+
+```rust
+/// Height determination strategy for inline mode.
+pub enum InlineHeight {
+    /// Fixed number of lines.
+    Fixed(u16),
+
+    /// Grow to fit content, with optional maximum.
+    Content { max: Option<u16> },
+
+    /// Fill remaining terminal space below cursor.
+    Fill { min: u16 },
 }
 ```
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -5,6 +5,7 @@ RxTUI is a reactive terminal user interface framework for Rust that brings moder
 ## Table of Contents
 
 - [Getting Started](#getting-started)
+- [Terminal Modes](#terminal-modes)
 - [Components](#components)
 - [The node! Macro](#the-node-macro)
 - [State Management](#state-management)
@@ -57,6 +58,87 @@ impl HelloWorld {
 fn main() -> std::io::Result<()> {
     App::new()?.run(HelloWorld)
 }
+```
+
+<div align='center'>• • •</div>
+
+## Terminal Modes
+
+RxTUI supports two terminal rendering modes: **Alternate Screen** (default) and **Inline**.
+
+#### Alternate Screen Mode (Default)
+
+The default mode uses the terminal's alternate screen buffer. This is ideal for full-screen applications:
+
+```rust
+fn main() -> std::io::Result<()> {
+    App::new()?.run(MyComponent)  // Uses alternate screen
+}
+```
+
+Characteristics:
+- Takes over the full terminal screen
+- Content disappears when the app exits
+- Best for interactive applications, editors, dashboards
+
+#### Inline Mode
+
+Inline mode renders directly in the terminal buffer without switching screens. Content persists after the app exits, making it ideal for CLI tools:
+
+```rust
+fn main() -> std::io::Result<()> {
+    // Simple inline mode with defaults
+    App::inline()?.run(MyComponent)?;
+
+    // This prints after the UI since content is preserved
+    println!("Done! The UI above is preserved.");
+    Ok(())
+}
+```
+
+Characteristics:
+- Renders in the main terminal buffer
+- Content persists in terminal history after exit
+- Height is content-based by default (grows to fit)
+- Mouse capture disabled by default (allows terminal scrolling)
+
+#### Custom Inline Configuration
+
+For fine-grained control over inline rendering:
+
+```rust
+use rxtui::{App, InlineConfig, InlineHeight};
+
+fn main() -> std::io::Result<()> {
+    let config = InlineConfig {
+        // Fixed height of 10 lines
+        height: InlineHeight::Fixed(10),
+        // Show cursor during rendering
+        cursor_visible: true,
+        // Preserve output after exit
+        preserve_on_exit: true,
+        // Don't capture mouse (allow terminal scrolling)
+        mouse_capture: false,
+    };
+
+    App::inline_with_config(config)?.run(MyComponent)
+}
+```
+
+#### Height Modes
+
+Control how inline mode determines rendering height:
+
+```rust
+// Fixed number of lines
+InlineHeight::Fixed(10)
+
+// Grow to fit content, with optional maximum
+InlineHeight::Content { max: Some(24) }  // Max 24 lines
+InlineHeight::Content { max: None }       // No limit (default)
+
+// Fill remaining terminal space below cursor
+InlineHeight::Fill { min: 5 }  // At least 5 lines
 ```
 
 <div align='center'>• • •</div>

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -617,6 +617,31 @@ Action::exit()              // Exit app
 
 ## App Configuration
 
+### Terminal Modes
+
+```rust
+// Alternate screen mode (default) - full-screen, content disappears on exit
+App::new()?.run(MyComponent)?;
+
+// Inline mode - renders in terminal, content persists after exit
+App::inline()?.run(MyComponent)?;
+
+// Custom inline configuration
+use rxtui::{InlineConfig, InlineHeight};
+
+let config = InlineConfig {
+    height: InlineHeight::Fixed(10),      // Fixed 10 lines
+    // height: InlineHeight::Content { max: Some(24) },  // Grow to fit, max 24
+    // height: InlineHeight::Fill { min: 5 },            // Fill remaining space
+    cursor_visible: false,
+    preserve_on_exit: true,               // Keep output after exit
+    mouse_capture: false,                 // Allow terminal scrolling
+};
+App::inline_with_config(config)?.run(MyComponent)?;
+```
+
+### Render Config
+
 ```rust
 let mut app = App::new()?
     .render_config(RenderConfig {
@@ -669,3 +694,4 @@ Includes:
 - Macros: `node!`, `#[component]`, `#[update]`, `#[view]`, `#[effect]`
 - Components: `TextInput`
 - Keys: `Key`, `KeyWithModifiers`
+- Terminal Modes: `TerminalMode`, `InlineConfig`, `InlineHeight`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ We bring the retained-mode, component-based architecture that revolutionized web
 - [x] **True Composability** - Build complex apps from simple, reusable components
 - [x] **Best of Both Worlds** - Elm's message architecture meets React's components
 - [x] **TUI Optimizations** - Automatic diffing, dirty tracking, and minimal redraws
+- [x] **Inline Mode** - Render directly in terminal with persistent output for CLI tools
 
 <br />
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -167,6 +167,21 @@ Simple loading animation demonstration:
 
 <br />
 
+### [inline.rs](./inline.rs)
+```bash
+cargo run --example inline
+```
+
+Demonstrates inline rendering mode:
+- Renders directly in terminal without alternate screen
+- Content persists in terminal history after app exits
+- Multiple interactive widgets (counter, status, scrollable log)
+- Tab-based focus navigation between components
+- Ideal for CLI tools that want persistent inline output
+- Shows `App::inline()` usage with content-based height
+
+<br />
+
 ## Feature Showcase
 
 ### [demo.rs](./demo.rs)

--- a/examples/inline.rs
+++ b/examples/inline.rs
@@ -1,0 +1,198 @@
+//! Inline Mode Example
+//!
+//! Demonstrates rendering directly in the terminal without alternate screen.
+//! Features multiple stacked components including a scrollable list.
+//! Content persists after the app exits, making it suitable for CLI tools.
+
+use rxtui::prelude::*;
+
+//--------------------------------------------------------------------------------------------------
+// Constants
+//--------------------------------------------------------------------------------------------------
+
+const LOG_ENTRIES: &[&str] = &[
+    "[INFO]  Application started successfully",
+    "[DEBUG] Loading configuration from ~/.config/app.toml",
+    "[INFO]  Connected to database at localhost:5432",
+    "[WARN]  Cache miss for key: user_preferences",
+    "[DEBUG] Fetching user data from remote API",
+    "[INFO]  User authentication successful",
+    "[DEBUG] Session token generated: abc...xyz",
+    "[INFO]  Loading plugin: syntax-highlighter v2.1.0",
+    "[INFO]  Loading plugin: auto-complete v1.5.3",
+    "[WARN]  Plugin deprecated: legacy-formatter",
+    "[DEBUG] Initializing render pipeline",
+    "[INFO]  Theme loaded: dark-ocean",
+    "[DEBUG] Font metrics calculated: 14px mono",
+    "[INFO]  Workspace opened: ~/projects/rxtui",
+    "[DEBUG] Indexing 1,247 files...",
+    "[INFO]  Index complete in 0.8s",
+    "[WARN]  Large file skipped: binary.dat (50MB)",
+    "[DEBUG] LSP server starting: rust-analyzer",
+    "[INFO]  LSP ready after 2.3s",
+    "[DEBUG] Registering keyboard shortcuts",
+    "[INFO]  Ready for input",
+];
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum Msg {
+    TogglePause,
+    IncrementCounter,
+    DecrementCounter,
+    Exit,
+}
+
+#[derive(Debug, Clone, Default)]
+struct AppState {
+    counter: i32,
+    paused: bool,
+    selected_log: usize,
+}
+
+#[derive(Component)]
+struct InlineDemo;
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl InlineDemo {
+    #[update]
+    fn update(&self, _ctx: &Context, msg: Msg, mut state: AppState) -> Action {
+        match msg {
+            Msg::TogglePause => {
+                state.paused = !state.paused;
+                Action::update(state)
+            }
+            Msg::IncrementCounter => {
+                state.counter += 1;
+                Action::update(state)
+            }
+            Msg::DecrementCounter => {
+                state.counter -= 1;
+                Action::update(state)
+            }
+            Msg::Exit => Action::exit(),
+        }
+    }
+
+    #[view]
+    fn view(&self, ctx: &Context, state: AppState) -> Node {
+        // Build log entries with color coding
+        let logs: Vec<Node> = LOG_ENTRIES
+            .iter()
+            .enumerate()
+            .map(|(i, line)| {
+                let color = if line.contains("[ERROR]") {
+                    Color::Red
+                } else if line.contains("[WARN]") {
+                    Color::Yellow
+                } else if line.contains("[DEBUG]") {
+                    Color::BrightBlack
+                } else {
+                    Color::Cyan
+                };
+
+                let prefix = if i == state.selected_log {
+                    "▶ "
+                } else {
+                    "  "
+                };
+                node! { text(format!("{prefix}{line}"), color: (color)) }
+            })
+            .collect();
+
+        node! {
+            div(
+                dir: vertical,
+                gap: 1,
+                w_frac: 1.0,
+                @key_global(esc): ctx.handler(Msg::Exit)
+            ) [
+                // Stats Row
+                hstack(gap: 2) [
+                    // Counter widget
+                    div(
+                        border_style: rounded,
+                        border_color: magenta,
+                        pad: 1,
+                        w: 24,
+                        focusable,
+                        @key(up): ctx.handler(Msg::IncrementCounter),
+                        @key(down): ctx.handler(Msg::DecrementCounter)
+                    ) [
+                        vstack(gap: 1, align: center) [
+                            text("Counter", color: magenta, bold),
+                            text(format!("{:+}", state.counter), color: white, bold),
+                            text("↑/↓ to change", color: bright_black)
+                        ]
+                    ],
+
+                    // Status widget
+                    div(
+                        border_style: rounded,
+                        border_color: (if state.paused { Color::Yellow } else { Color::Green }),
+                        pad: 1,
+                        w: 24,
+                        focusable,
+                        @char('p'): ctx.handler(Msg::TogglePause)
+                    ) [
+                        vstack(gap: 1, align: center) [
+                            text("Status", color: (if state.paused { Color::Yellow } else { Color::Green }), bold),
+                            text(
+                                if state.paused { "⏸ PAUSED" } else { "▶ RUNNING" },
+                                color: white,
+                                bold
+                            ),
+                            text("p to toggle", color: bright_black)
+                        ]
+                    ],
+                ],
+
+                // Scrollable Log Section (tall content to test viewport occlusion)
+                div(
+                    border_style: rounded,
+                    border_color: bright_black,
+                    pad: 1,
+                    h: 12,
+                    focusable
+                ) [
+                    vstack(gap: 0, overflow: scroll,) [
+                        text("─── Application Log ───", color: bright_black, bold),
+                        ...(logs)
+                    ]
+                ],
+
+                // Footer
+                div(pad_h: 1) [
+                    richtext [
+                        text("tab", color: cyan),
+                        text(" focus │ ", color: bright_black),
+                        text("esc", color: cyan),
+                        text(" exit │ ", color: bright_black),
+                        text("Content persists after exit!", color: yellow)
+                    ]
+                ]
+            ]
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Functions
+//--------------------------------------------------------------------------------------------------
+
+fn main() -> std::io::Result<()> {
+    // Use App::inline() for inline rendering mode
+    // Content will persist after exit (preserve_on_exit is true by default)
+    App::inline()?.run(InlineDemo)?;
+
+    // This message appears after the UI since content is preserved
+    println!("\nDemo completed. Notice the UI above is preserved!");
+
+    Ok(())
+}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,612 @@
+# Inline Rendering Mode for rxtui
+
+## Problem Statement
+
+rxtui currently renders exclusively to the terminal's alternate screen buffer. This mode:
+- Clears the terminal and takes over the full screen
+- Content disappears when the app exits
+- Not suitable for CLI tools that want persistent inline output
+
+**Goal**: Add inline rendering mode that renders directly in the terminal without alternate screen, with proper terminal scrolling support.
+
+---
+
+## Terminal Scrolling Nuances
+
+### The Core Challenge
+
+When rendering inline (not in alternate screen), terminal scrolling creates coordinate system problems:
+
+```
+Before rendering (cursor at row 45 of 50-row terminal):
+┌─────────────────────────┐
+│ ... terminal history    │ row 1-44
+│ cursor here ►           │ row 45
+│                         │ row 46-50 (empty)
+└─────────────────────────┘
+
+After printing 10 lines:
+┌─────────────────────────┐
+│ ... terminal history    │ rows shifted up by 5
+│ our line 1              │
+│ our line 2              │
+│ ...                     │
+│ our line 10             │ row 50
+└─────────────────────────┘
+
+Problem: Our "starting position" (row 45) no longer exists at row 45!
+         It scrolled up. Re-rendering to row 45 writes to wrong location.
+```
+
+### Strategy: Space Reservation
+
+Reserve rendering space BEFORE drawing content. This guarantees we have room and establishes a stable coordinate system.
+
+```
+Step 1: Query cursor position → (col=0, row=45)
+Step 2: Calculate content height → 10 lines
+Step 3: Print 10 newlines (reserves space, causes scroll if needed)
+Step 4: Move cursor back up 10 lines → now at stable "origin"
+Step 5: Render content → writes into reserved space
+Step 6: On re-render → move to origin, overwrite in place
+```
+
+**Why this works**: After reservation, all scrolling has already happened. The origin position is stable for the lifetime of the app.
+
+---
+
+## Comprehensive Design
+
+### 1. New Types
+
+**File**: `lib/app/config.rs`
+
+```rust
+/// Terminal rendering mode
+pub enum TerminalMode {
+    /// Full-screen alternate buffer (current behavior)
+    AlternateScreen,
+    /// Inline rendering in main terminal buffer
+    Inline(InlineConfig),
+}
+
+/// Configuration for inline rendering mode
+pub struct InlineConfig {
+    /// How to determine rendering height
+    pub height: InlineHeight,
+    /// Whether to show cursor during rendering
+    pub cursor_visible: bool,
+    /// Whether to preserve output after app exits
+    pub preserve_on_exit: bool,
+}
+
+/// Height determination strategy for inline mode
+pub enum InlineHeight {
+    /// Fixed number of lines
+    Fixed(u16),
+    /// Grow to fit content, with optional maximum
+    Content { max: Option<u16> },
+    /// Fill remaining terminal space below cursor
+    Fill { min: u16 },
+}
+
+impl Default for InlineConfig {
+    fn default() -> Self {
+        Self {
+            height: InlineHeight::Content { max: Some(24) },
+            cursor_visible: false,
+            preserve_on_exit: true,
+        }
+    }
+}
+```
+
+**File**: `lib/app/inline.rs` (new file)
+
+```rust
+/// Runtime state for inline rendering
+pub(crate) struct InlineState {
+    /// Row where our rendering area starts (after space reservation)
+    pub origin_row: u16,
+    /// Column where rendering starts (usually 0)
+    pub origin_col: u16,
+    /// Current reserved height
+    pub reserved_height: u16,
+    /// Terminal dimensions at initialization
+    pub terminal_size: (u16, u16),
+    /// Whether space has been reserved
+    pub initialized: bool,
+}
+
+impl InlineState {
+    pub fn new() -> Self {
+        Self {
+            origin_row: 0,
+            origin_col: 0,
+            reserved_height: 0,
+            terminal_size: (80, 24),
+            initialized: false,
+        }
+    }
+}
+```
+
+### 2. Space Reservation Algorithm
+
+**File**: `lib/app/inline.rs`
+
+```rust
+impl InlineState {
+    /// Reserve space for inline rendering
+    /// Must be called before first render
+    pub fn reserve_space(
+        &mut self,
+        stdout: &mut impl Write,
+        height: u16,
+    ) -> io::Result<()> {
+        // 1. Get terminal dimensions
+        let (term_width, term_height) = terminal::size()?;
+        self.terminal_size = (term_width, term_height);
+
+        // 2. Query current cursor position
+        let (cursor_col, cursor_row) = cursor::position()?;
+
+        // 3. Calculate how many lines we can use
+        let available_below = term_height.saturating_sub(cursor_row);
+        let need_to_scroll = height.saturating_sub(available_below);
+
+        // 4. Print newlines to reserve space (causes scroll if needed)
+        for _ in 0..height {
+            stdout.execute(Print("\n"))?;
+        }
+
+        // 5. Move cursor back up to origin
+        stdout.execute(cursor::MoveUp(height))?;
+
+        // 6. Query new position (this is our stable origin)
+        let (new_col, new_row) = cursor::position()?;
+        self.origin_row = new_row;
+        self.origin_col = new_col;
+        self.reserved_height = height;
+        self.initialized = true;
+
+        Ok(())
+    }
+
+    /// Expand reserved space if content grew
+    pub fn expand_space(
+        &mut self,
+        stdout: &mut impl Write,
+        new_height: u16,
+    ) -> io::Result<()> {
+        if new_height <= self.reserved_height {
+            return Ok(());
+        }
+
+        let additional = new_height - self.reserved_height;
+
+        // Move to end of current reserved area
+        stdout.execute(cursor::MoveTo(
+            0,
+            self.origin_row + self.reserved_height,
+        ))?;
+
+        // Print additional newlines
+        for _ in 0..additional {
+            stdout.execute(Print("\n"))?;
+        }
+
+        // Origin shifts up if we scrolled
+        let (_, term_height) = self.terminal_size;
+        let bottom_row = self.origin_row + new_height;
+        if bottom_row > term_height {
+            let scroll_amount = bottom_row - term_height;
+            self.origin_row = self.origin_row.saturating_sub(scroll_amount);
+        }
+
+        self.reserved_height = new_height;
+        Ok(())
+    }
+
+    /// Move cursor to origin for rendering
+    pub fn move_to_origin(&self, stdout: &mut impl Write) -> io::Result<()> {
+        stdout.execute(cursor::MoveTo(self.origin_col, self.origin_row))?;
+        Ok(())
+    }
+
+    /// Move cursor to end of rendered content (for exit)
+    pub fn move_to_end(&self, stdout: &mut impl Write) -> io::Result<()> {
+        stdout.execute(cursor::MoveTo(0, self.origin_row + self.reserved_height))?;
+        stdout.execute(Print("\n"))?; // Ensure prompt appears below
+        Ok(())
+    }
+}
+```
+
+### 3. Height Calculation for Inline Mode
+
+**File**: `lib/render_tree/tree.rs`
+
+The key change: don't clamp height to viewport for inline Content mode.
+
+```rust
+pub fn layout(&mut self, viewport_width: u16, viewport_height: u16, unclamped_height: bool) {
+    // ... existing code ...
+
+    // Height resolution with optional unclamping
+    match height_dim {
+        Some(Dimension::Fixed(h)) => {
+            root_ref.height = if unclamped_height { h } else { h.min(viewport_height) };
+        }
+        Some(Dimension::Percentage(pct)) => {
+            let calculated = (viewport_height as f32 * pct) as u16;
+            root_ref.height = calculated.max(1);
+            if !unclamped_height {
+                root_ref.height = root_ref.height.min(viewport_height);
+            }
+        }
+        Some(Dimension::Content) | None => {
+            // For Content or None, use intrinsic height
+            // Only clamp if not in unclamped mode
+            root_ref.height = if unclamped_height {
+                intrinsic_height
+            } else {
+                intrinsic_height.min(viewport_height)
+            };
+        }
+        Some(Dimension::Auto) => {
+            root_ref.height = viewport_height; // Auto still fills available space
+        }
+    }
+
+    // ... continue with layout_with_parent ...
+}
+```
+
+### 4. Modified App Initialization
+
+**File**: `lib/app/core.rs`
+
+```rust
+impl App {
+    /// Create app with specified terminal mode
+    pub fn with_mode<C: Component + 'static>(
+        root: C,
+        mode: TerminalMode,
+    ) -> io::Result<Self> {
+        let mut stdout = io::stdout();
+
+        // Always enable raw mode for event handling
+        terminal::enable_raw_mode()?;
+
+        match &mode {
+            TerminalMode::AlternateScreen => {
+                stdout.execute(terminal::EnterAlternateScreen)?;
+                stdout.execute(cursor::Hide)?;
+            }
+            TerminalMode::Inline(config) => {
+                if !config.cursor_visible {
+                    stdout.execute(cursor::Hide)?;
+                }
+                // Space reservation happens on first render
+            }
+        }
+
+        stdout.execute(event::EnableMouseCapture)?;
+
+        let (width, height) = terminal::size()?;
+
+        Ok(Self {
+            // ... existing fields ...
+            terminal_mode: mode,
+            inline_state: InlineState::new(),
+        })
+    }
+
+    /// Convenience constructor for inline mode with defaults
+    pub fn inline<C: Component + 'static>(root: C) -> io::Result<Self> {
+        Self::with_mode(root, TerminalMode::Inline(InlineConfig::default()))
+    }
+}
+```
+
+### 5. Modified Rendering Pipeline
+
+**File**: `lib/app/core.rs`
+
+```rust
+impl App {
+    fn draw(&mut self) -> io::Result<()> {
+        match &self.terminal_mode {
+            TerminalMode::AlternateScreen => {
+                self.draw_alternate_screen()
+            }
+            TerminalMode::Inline(config) => {
+                self.draw_inline(config)
+            }
+        }
+    }
+
+    fn draw_inline(&mut self, config: &InlineConfig) -> io::Result<()> {
+        let mut stdout = io::stdout();
+
+        // Calculate content dimensions
+        let (term_width, term_height) = terminal::size()?;
+        let unclamped = matches!(config.height, InlineHeight::Content { .. });
+
+        // Layout with potentially unclamped height
+        let layout_height = match &config.height {
+            InlineHeight::Fixed(h) => *h,
+            InlineHeight::Content { max } => max.unwrap_or(term_height),
+            InlineHeight::Fill { min } => {
+                let available = term_height.saturating_sub(self.inline_state.origin_row);
+                available.max(*min)
+            }
+        };
+
+        self.vdom.layout(term_width, layout_height, unclamped);
+
+        // Get actual content height from rendered tree
+        let content_height = self.vdom.render_tree()
+            .and_then(|rt| rt.root.as_ref().map(|r| r.borrow().height))
+            .unwrap_or(1);
+
+        // Apply height limits
+        let render_height = match &config.height {
+            InlineHeight::Fixed(h) => *h,
+            InlineHeight::Content { max } => {
+                max.map(|m| content_height.min(m)).unwrap_or(content_height)
+            }
+            InlineHeight::Fill { min } => content_height.max(*min),
+        };
+
+        // Initialize or expand space reservation
+        if !self.inline_state.initialized {
+            self.inline_state.reserve_space(&mut stdout, render_height)?;
+        } else if render_height > self.inline_state.reserved_height {
+            self.inline_state.expand_space(&mut stdout, render_height)?;
+        }
+
+        // Move to origin
+        self.inline_state.move_to_origin(&mut stdout)?;
+
+        // Render to buffer
+        self.double_buffer.clear_back();
+        let root = self.vdom.render_tree().unwrap().root.clone().unwrap();
+        let clip_rect = Rect {
+            x: 0,
+            y: 0,
+            width: term_width,
+            height: render_height,
+        };
+        render_node_to_buffer(&root.borrow(), &mut self.double_buffer.back_mut(), &clip_rect, None);
+
+        // Apply updates with line-based clearing
+        let updates = self.double_buffer.diff();
+        self.terminal_renderer.apply_updates_inline(updates, self.inline_state.origin_row)?;
+
+        self.double_buffer.swap();
+        stdout.flush()?;
+
+        Ok(())
+    }
+}
+```
+
+### 6. Modified Terminal Renderer
+
+**File**: `lib/terminal.rs`
+
+```rust
+impl TerminalRenderer {
+    /// Apply updates for inline mode with origin offset
+    pub fn apply_updates_inline(
+        &mut self,
+        updates: Vec<CellUpdate>,
+        origin_row: u16,
+    ) -> io::Result<()> {
+        // Transform coordinates to account for origin
+        let transformed: Vec<CellUpdate> = updates
+            .into_iter()
+            .map(|update| match update {
+                CellUpdate::Single { x, y, cell } => CellUpdate::Single {
+                    x,
+                    y: y + origin_row,
+                    cell,
+                },
+            })
+            .collect();
+
+        // Use existing optimized update path
+        self.apply_updates_optimized(transformed)?;
+        Ok(())
+    }
+
+    /// Clear specific lines (for inline mode)
+    pub fn clear_lines(&mut self, start_row: u16, count: u16) -> io::Result<()> {
+        for row in start_row..(start_row + count) {
+            self.stdout.execute(cursor::MoveTo(0, row))?;
+            self.stdout.execute(terminal::Clear(terminal::ClearType::CurrentLine))?;
+        }
+        self.current_pos = None;
+        Ok(())
+    }
+}
+```
+
+### 7. Modified Cleanup
+
+**File**: `lib/app/core.rs`
+
+```rust
+impl Drop for App {
+    fn drop(&mut self) {
+        let mut stdout = io::stdout();
+
+        let _ = stdout.execute(event::DisableMouseCapture);
+        let _ = stdout.execute(cursor::Show);
+
+        match &self.terminal_mode {
+            TerminalMode::AlternateScreen => {
+                let _ = stdout.execute(terminal::LeaveAlternateScreen);
+            }
+            TerminalMode::Inline(config) => {
+                if config.preserve_on_exit {
+                    // Move cursor below rendered content
+                    let _ = self.inline_state.move_to_end(&mut stdout);
+                } else {
+                    // Clear the inline rendering area
+                    let _ = self.terminal_renderer.clear_lines(
+                        self.inline_state.origin_row,
+                        self.inline_state.reserved_height,
+                    );
+                    let _ = stdout.execute(cursor::MoveTo(
+                        self.inline_state.origin_col,
+                        self.inline_state.origin_row,
+                    ));
+                }
+            }
+        }
+
+        let _ = stdout.flush();
+        let _ = terminal::disable_raw_mode();
+    }
+}
+```
+
+### 8. Event Handling Changes
+
+**File**: `lib/app/core.rs`
+
+```rust
+// In run_loop(), modify resize handling:
+Event::Resize(width, height) => {
+    match &self.terminal_mode {
+        TerminalMode::AlternateScreen => {
+            // Existing behavior: full re-layout and clear
+            self.vdom.layout(width, height, false);
+            self.double_buffer.resize(width, height);
+            self.double_buffer.reset();
+            self.terminal_renderer.clear_screen()?;
+        }
+        TerminalMode::Inline(_) => {
+            // Inline mode: only handle width changes
+            // Height is managed by space reservation
+            self.inline_state.terminal_size = (width, height);
+            // Re-render will handle layout
+        }
+    }
+    *self.needs_render.borrow_mut() = true;
+}
+
+// Mouse event coordinate translation for inline mode:
+Event::Mouse(mouse_event) => {
+    let adjusted_event = match &self.terminal_mode {
+        TerminalMode::Inline(_) => {
+            // Translate coordinates relative to origin
+            let adjusted_row = mouse_event.row
+                .saturating_sub(self.inline_state.origin_row);
+            MouseEvent {
+                row: adjusted_row,
+                ..mouse_event
+            }
+        }
+        _ => mouse_event,
+    };
+    // ... existing mouse handling with adjusted_event ...
+}
+```
+
+---
+
+## Implementation Order
+
+### Phase 1: Foundation (Core Types & Config)
+1. Add `TerminalMode`, `InlineConfig`, `InlineHeight` enums to `config.rs`
+2. Create `inline.rs` with `InlineState` struct
+3. Add `terminal_mode` and `inline_state` fields to `App` struct
+4. Update `App::new()` to accept mode, create `App::with_mode()` and `App::inline()`
+
+### Phase 2: Space Reservation
+1. Implement `InlineState::reserve_space()` with cursor position query
+2. Implement `InlineState::expand_space()` for dynamic height growth
+3. Implement `InlineState::move_to_origin()` and `move_to_end()`
+4. Add `TerminalRenderer::clear_lines()` for line-based clearing
+
+### Phase 3: Layout Changes
+1. Add `unclamped_height: bool` parameter to `RenderTree::layout()`
+2. Modify height clamping logic to respect unclamped flag
+3. Ensure intrinsic height calculation works correctly for Content mode
+
+### Phase 4: Rendering Pipeline
+1. Implement `App::draw_inline()` method
+2. Add `TerminalRenderer::apply_updates_inline()` with origin offset
+3. Integrate space reservation into first render
+4. Handle height expansion on subsequent renders
+
+### Phase 5: Cleanup & Events
+1. Modify `Drop` implementation for inline mode cleanup
+2. Add mouse coordinate translation for inline mode
+3. Modify resize event handling (width-only for inline)
+4. Add `preserve_on_exit` behavior
+
+### Phase 6: Testing & Polish
+1. Create inline mode examples
+2. Test with various terminal emulators
+3. Handle edge cases (very small terminals, rapid resizing)
+4. Document public API
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `lib/app/config.rs` | Add `TerminalMode`, `InlineConfig`, `InlineHeight` |
+| `lib/app/inline.rs` | New file: `InlineState` implementation |
+| `lib/app/core.rs` | `App::with_mode()`, `App::inline()`, `draw_inline()`, modified `Drop` |
+| `lib/app/mod.rs` | Export new types and inline module |
+| `lib/render_tree/tree.rs` | Add `unclamped_height` parameter to `layout()` |
+| `lib/terminal.rs` | `apply_updates_inline()`, `clear_lines()` |
+| `lib/lib.rs` | Re-export `TerminalMode`, `InlineConfig`, `InlineHeight` |
+
+---
+
+## API Usage Example
+
+```rust
+use rxtui::{App, InlineConfig, InlineHeight, TerminalMode};
+
+// Simple inline mode with defaults
+let app = App::inline(MyComponent)?;
+app.run()?;
+
+// Custom inline configuration
+let config = InlineConfig {
+    height: InlineHeight::Fixed(10),
+    cursor_visible: true,
+    preserve_on_exit: true,
+};
+let app = App::with_mode(MyComponent, TerminalMode::Inline(config))?;
+app.run()?;
+
+// Content-based height with max
+let config = InlineConfig {
+    height: InlineHeight::Content { max: Some(20) },
+    ..Default::default()
+};
+let app = App::with_mode(MyComponent, TerminalMode::Inline(config))?;
+app.run()?;
+```
+
+---
+
+## Edge Cases & Considerations
+
+1. **Terminal too small**: If terminal height < requested inline height, clamp to available space
+2. **Cursor position query fails**: Fall back to assuming cursor is at terminal height (worst case, reserve full space)
+3. **Content shrinks**: Don't reduce reserved space (could leave gaps), just render less
+4. **Very rapid updates**: Existing double-buffering and diffing still applies
+5. **Mouse clicks outside area**: Ignore or pass through based on config
+6. **No synchronized output**: Inline mode should work without it (most terminals support)
+7. **Piped output**: Detect `!isatty()` and use simplified output mode

--- a/rxtui/lib/app/config.rs
+++ b/rxtui/lib/app/config.rs
@@ -2,6 +2,53 @@
 // Types
 //--------------------------------------------------------------------------------------------------
 
+/// Terminal rendering mode.
+#[derive(Clone, Default)]
+pub enum TerminalMode {
+    /// Full-screen alternate buffer (default behavior).
+    /// Content disappears when app exits.
+    #[default]
+    AlternateScreen,
+
+    /// Inline rendering in main terminal buffer.
+    /// Content persists in terminal history after app exits.
+    Inline(InlineConfig),
+}
+
+/// Configuration for inline rendering mode.
+#[derive(Clone)]
+pub struct InlineConfig {
+    /// How to determine rendering height.
+    pub height: InlineHeight,
+
+    /// Whether to show cursor during rendering.
+    pub cursor_visible: bool,
+
+    /// Whether to preserve output after app exits.
+    pub preserve_on_exit: bool,
+
+    /// Whether to capture mouse events.
+    ///
+    /// Default is `false` to allow natural terminal scrolling.
+    /// Set to `true` if you need mouse interaction (clicks, hover)
+    /// within the inline UI, but note this will prevent terminal
+    /// scrollbar and scroll gestures from working.
+    pub mouse_capture: bool,
+}
+
+/// Height determination strategy for inline mode.
+#[derive(Clone)]
+pub enum InlineHeight {
+    /// Fixed number of lines.
+    Fixed(u16),
+
+    /// Grow to fit content, with optional maximum.
+    Content { max: Option<u16> },
+
+    /// Fill remaining terminal space below cursor.
+    Fill { min: u16 },
+}
+
 /// Configuration options for debugging and optimization control.
 #[derive(Clone)]
 pub struct RenderConfig {
@@ -38,6 +85,25 @@ impl RenderConfig {
 //--------------------------------------------------------------------------------------------------
 // Trait Implementations
 //--------------------------------------------------------------------------------------------------
+
+impl Default for InlineConfig {
+    fn default() -> Self {
+        Self {
+            // Default to content-based height with no max limit.
+            // Users can set a max if they want to constrain height.
+            height: InlineHeight::Content { max: None },
+            cursor_visible: false,
+            preserve_on_exit: true,
+            mouse_capture: false,
+        }
+    }
+}
+
+impl Default for InlineHeight {
+    fn default() -> Self {
+        Self::Content { max: None }
+    }
+}
 
 impl Default for RenderConfig {
     fn default() -> Self {

--- a/rxtui/lib/app/inline.rs
+++ b/rxtui/lib/app/inline.rs
@@ -1,0 +1,179 @@
+use crossterm::{ExecutableCommand, cursor, style::Print, terminal};
+use std::io::{self, Write};
+
+//--------------------------------------------------------------------------------------------------
+// Types
+//--------------------------------------------------------------------------------------------------
+
+/// Runtime state for inline rendering.
+///
+/// Tracks the position and dimensions of the inline rendering area
+/// within the terminal's main buffer.
+pub(crate) struct InlineState {
+    /// Row where our rendering area starts (after space reservation).
+    pub origin_row: u16,
+    /// Column where rendering starts (usually 0).
+    pub origin_col: u16,
+    /// Current reserved height.
+    pub reserved_height: u16,
+    /// Terminal dimensions at initialization.
+    pub terminal_size: (u16, u16),
+    /// Whether space has been reserved.
+    pub initialized: bool,
+}
+
+//--------------------------------------------------------------------------------------------------
+// Methods
+//--------------------------------------------------------------------------------------------------
+
+impl InlineState {
+    /// Creates a new uninitialized inline state.
+    pub fn new() -> Self {
+        Self {
+            origin_row: 0,
+            origin_col: 0,
+            reserved_height: 0,
+            terminal_size: (80, 24),
+            initialized: false,
+        }
+    }
+
+    /// Reserve space for inline rendering.
+    ///
+    /// This must be called before the first render. It:
+    /// 1. Queries current cursor position
+    /// 2. Prints newlines to reserve space (causing scroll if needed)
+    /// 3. Moves cursor back up to establish a stable origin
+    /// 4. Clears the reserved area to prevent artifacts from existing terminal content
+    ///
+    /// After this call, `origin_row` and `origin_col` define a stable
+    /// coordinate system for rendering.
+    pub fn reserve_space(&mut self, stdout: &mut impl Write, height: u16) -> io::Result<()> {
+        // Get terminal dimensions
+        let (term_width, term_height) = terminal::size()?;
+        self.terminal_size = (term_width, term_height);
+
+        // Query current cursor position (used for debugging, but we rely on new_row/new_col below)
+        let (_cursor_col, _cursor_row) = cursor::position()?;
+
+        // Clamp height to terminal height if needed
+        let height = height.min(term_height);
+
+        // Print newlines to reserve space (causes scroll if needed)
+        for _ in 0..height {
+            stdout.execute(Print("\n"))?;
+        }
+
+        // Move cursor back up to origin
+        if height > 0 {
+            stdout.execute(cursor::MoveUp(height))?;
+        }
+
+        // Query new position - this is our stable origin
+        let (new_col, new_row) = cursor::position()?;
+        self.origin_row = new_row;
+        self.origin_col = new_col;
+        self.reserved_height = height;
+        self.initialized = true;
+
+        // Clear the reserved area to remove any existing terminal content.
+        // This ensures our front buffer (all empty cells) matches the actual terminal state.
+        // Without this, artifacts can appear where existing content wasn't overwritten.
+        self.clear_area(stdout, height)?;
+
+        Ok(())
+    }
+
+    /// Clear the reserved inline area.
+    ///
+    /// Clears each line in the reserved area to ensure no existing terminal
+    /// content interferes with rendering.
+    fn clear_area(&self, stdout: &mut impl Write, height: u16) -> io::Result<()> {
+        for row in 0..height {
+            stdout.execute(cursor::MoveTo(0, self.origin_row + row))?;
+            stdout.execute(terminal::Clear(terminal::ClearType::CurrentLine))?;
+        }
+        // Move cursor back to origin after clearing
+        stdout.execute(cursor::MoveTo(self.origin_col, self.origin_row))?;
+        Ok(())
+    }
+
+    /// Expand reserved space if content grew.
+    ///
+    /// If the new height is greater than current reserved height,
+    /// adds more newlines, clears the new area, and adjusts origin if scrolling occurred.
+    pub fn expand_space(&mut self, stdout: &mut impl Write, new_height: u16) -> io::Result<()> {
+        if new_height <= self.reserved_height {
+            return Ok(());
+        }
+
+        let additional = new_height - self.reserved_height;
+        let old_height = self.reserved_height;
+
+        // Move to end of current reserved area
+        stdout.execute(cursor::MoveTo(0, self.origin_row + self.reserved_height))?;
+
+        // Print additional newlines
+        for _ in 0..additional {
+            stdout.execute(Print("\n"))?;
+        }
+
+        // Check if we scrolled - origin shifts up if bottom exceeds terminal
+        let (_, term_height) = self.terminal_size;
+        let bottom_row = self.origin_row + new_height;
+        if bottom_row > term_height {
+            let scroll_amount = bottom_row - term_height;
+            self.origin_row = self.origin_row.saturating_sub(scroll_amount);
+        }
+
+        self.reserved_height = new_height;
+
+        // Clear only the newly added lines
+        for row in old_height..new_height {
+            stdout.execute(cursor::MoveTo(0, self.origin_row + row))?;
+            stdout.execute(terminal::Clear(terminal::ClearType::CurrentLine))?;
+        }
+
+        Ok(())
+    }
+
+    /// Move cursor to origin for rendering.
+    #[allow(dead_code)]
+    pub fn move_to_origin(&self, stdout: &mut impl Write) -> io::Result<()> {
+        stdout.execute(cursor::MoveTo(self.origin_col, self.origin_row))?;
+        Ok(())
+    }
+
+    /// Move cursor to end of rendered content (for exit).
+    ///
+    /// Positions cursor below the rendered area and prints a newline
+    /// to ensure the shell prompt appears on a fresh line.
+    pub fn move_to_end(&self, stdout: &mut impl Write) -> io::Result<()> {
+        stdout.execute(cursor::MoveTo(0, self.origin_row + self.reserved_height))?;
+        stdout.execute(Print("\n"))?;
+        Ok(())
+    }
+
+    /// Translate a terminal row to a row relative to our origin.
+    ///
+    /// Used for translating mouse event coordinates.
+    #[allow(dead_code)]
+    pub fn translate_row(&self, terminal_row: u16) -> Option<u16> {
+        if terminal_row >= self.origin_row && terminal_row < self.origin_row + self.reserved_height
+        {
+            Some(terminal_row - self.origin_row)
+        } else {
+            None
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trait Implementations
+//--------------------------------------------------------------------------------------------------
+
+impl Default for InlineState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rxtui/lib/app/mod.rs
+++ b/rxtui/lib/app/mod.rs
@@ -2,11 +2,13 @@ pub mod config;
 pub mod context;
 pub mod core;
 pub mod events;
+pub(crate) mod inline;
 pub mod renderer;
 
 //--------------------------------------------------------------------------------------------------
 // Exports
 //--------------------------------------------------------------------------------------------------
 
+pub use config::{InlineConfig, InlineHeight, TerminalMode};
 pub use context::Context;
 pub use core::App;

--- a/rxtui/lib/lib.rs
+++ b/rxtui/lib/lib.rs
@@ -422,7 +422,7 @@ pub use rxtui_macros::{component, update, view};
 #[cfg(feature = "effects")]
 pub use rxtui_macros::effect;
 
-pub use app::{App, Context};
+pub use app::{App, Context, InlineConfig, InlineHeight, TerminalMode};
 pub use bounds::Rect;
 pub use component::{Action, Component, Message, MessageExt, State};
 #[cfg(feature = "components")]

--- a/rxtui/lib/vdom.rs
+++ b/rxtui/lib/vdom.rs
@@ -118,6 +118,15 @@ impl VDom {
         self.render_tree.layout(width, height);
     }
 
+    /// Performs layout calculation with additional options for inline mode.
+    ///
+    /// When `unclamped_height` is true, height is not clamped to viewport.
+    /// This is used for inline mode where content can grow beyond viewport bounds.
+    pub fn layout_with_options(&mut self, width: u16, height: u16, unclamped_height: bool) {
+        self.render_tree
+            .layout_with_options(width, height, unclamped_height);
+    }
+
     /// Gets a reference to the current render tree.
     ///
     /// Used by the App to access the tree for drawing and event handling.


### PR DESCRIPTION
PR Title: feat(app): add inline rendering mode for CLI tools

## Summary

- Add new terminal rendering mode that renders directly in the main terminal buffer
- Enable CLI tools to display persistent inline UIs that remain visible after app exits
- Provides alternative to full-screen alternate screen mode for lightweight terminal UIs
- Includes space reservation algorithm to handle terminal scrolling correctly

This feature addresses the need for CLI tools that want to show interactive UI elements
(progress bars, status displays, menus) that persist in terminal history rather than
disappearing when the application exits.

## Changes

### New Types (rxtui/lib/app/config.rs)
- `TerminalMode` enum with `AlternateScreen` (default) and `Inline` variants
- `InlineConfig` struct with height, cursor visibility, preserve_on_exit, and mouse_capture options
- `InlineHeight` enum with `Fixed`, `Content`, and `Fill` strategies

### New Module (rxtui/lib/app/inline.rs)
- `InlineState` struct tracking origin position and reserved height
- `reserve_space()` method for initial space reservation with scroll handling
- `expand_space()` method for dynamic height growth
- Coordinate translation helpers for mouse events

### App Core Changes (rxtui/lib/app/core.rs)
- `App::inline()` constructor for default inline mode
- `App::inline_with_config()` for custom configuration
- `App::with_mode()` core constructor for both modes
- `draw_inline()` rendering method with origin offset
- Modified `Drop` implementation for mode-specific cleanup

### Layout Changes (rxtui/lib/render_tree/tree.rs, rxtui/lib/vdom.rs)
- `layout_with_options()` method with `unclamped_height` parameter
- Allows content to grow beyond viewport bounds in inline mode

### Terminal Renderer (rxtui/lib/terminal.rs)
- `apply_updates_inline()` with origin row offset
- `clear_lines()` for line-based clearing
- Fixed display width calculation for Unicode characters

### Documentation Updates
- API_REFERENCE.md: Added TerminalMode, InlineConfig, InlineHeight types
- DOCS.md: Added Terminal Modes section with usage examples
- QUICK_REFERENCE.md: Added Terminal Modes configuration examples
- README.md: Added Inline Mode to feature list
- examples/README.md: Added inline.rs example entry

### New Example (examples/inline.rs)
- Demo with counter widget, status toggle, and scrollable log
- Shows Tab-based focus navigation in inline mode
- Demonstrates content persistence after exit

## Test Plan

- Run `cargo build` to verify successful compilation
- Run `cargo clippy` to ensure no linting errors
- Run `cargo test` to verify existing tests pass
- Run `cargo run --example inline` to test the inline mode demo:
  - Verify UI renders below cursor position in terminal
  - Use Tab to navigate between counter and status widgets
  - Press up/down to change counter value
  - Press 'p' to toggle pause status
  - Press Esc to exit
  - Verify UI content persists in terminal after exit
  - Verify shell prompt appears below the preserved content
