### PR TITLE
chore(release): bump version to 0.1.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rxtui-workspace"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 authors = ["Microsandbox Team"]
 license = "Apache-2.0"

--- a/rxtui/Cargo.toml
+++ b/rxtui/Cargo.toml
@@ -21,7 +21,7 @@ effects = ["tokio", "futures"]
 components = ["effects"]
 
 [dependencies]
-rxtui-macros = { version = "0.1.7", path = "../rxtui-macros" }
+rxtui-macros = { version = "0.1.8", path = "../rxtui-macros" }
 bitflags = "2.4"
 crossterm = "0.28"
 serde.workspace = true


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.1.7 to 0.1.8 for release preparation
- Update rxtui-macros dependency version to match workspace version
- Prepare release containing new features and bug fixes since 0.1.7

## Changes

**Version Updates:**
- `Cargo.toml`: Updated package version and workspace.package version from 0.1.7 to 0.1.8
- `rxtui/Cargo.toml`: Updated rxtui-macros dependency version from 0.1.7 to 0.1.8

**Changelog since 0.1.7:**
- feat(app): add inline rendering mode for CLI tools (#52)
- fix(layout): resolve percentage widths before intrinsic size calculation (#50)
- feat(div): add focus border styling support (#49)

## Test Plan

- Run `cargo build --workspace` to verify successful compilation
- Run `cargo test --workspace` to ensure all tests pass
- Run `cargo clippy --workspace` to check for warnings
- Note: `cargo publish --dry-run` for rxtui will fail until rxtui-macros 0.1.8 is published first